### PR TITLE
Feature equip item

### DIFF
--- a/champion.py
+++ b/champion.py
@@ -54,6 +54,7 @@ class BaseChampion:
         return self.item_stats.copy()
 
     def equip_item(self, item_name):
+        self.items.append(item_name)
         self.update_bonus_stat_with_item(self.item_stats, ALL_ITEM_STATS[item_name])
         self.bonus_stats = self.get_bonus_stats()
 

--- a/champion.py
+++ b/champion.py
@@ -73,9 +73,9 @@ class BaseChampion:
 
 # Dummy class for tests in practice tool.
 class Dummy:
-    def __init__(self, health: float, bonus_armor: float, bonus_magic_resist: float):
-        assert bonus_armor == bonus_magic_resist
-        assert bonus_armor % 10 == 0
+    def __init__(self, health: float, bonus_resistance: int):
+        """Dummy champion have the same armor and mr"""
+        assert bonus_resistance % 10 == 0
         assert health % 100 == 0
         assert health <= 10000
 
@@ -85,8 +85,8 @@ class Dummy:
         }
         self.orig_bonus_stats = {
             "health": health, 
-            "armor": bonus_armor, 
-            "magic_resist": bonus_magic_resist
+            "armor": bonus_resistance, 
+            "magic_resist": bonus_resistance
         }
 
 

--- a/champion.py
+++ b/champion.py
@@ -65,8 +65,8 @@ class BaseChampion:
 
         damage = damage_auto_attack(
             base_attack_damage=self.orig_base_stats["attack_damage"], 
-            bonus_attack_damage=bonus_attack_damage,
             base_armor=enemy_champion.orig_base_stats["armor"],
+            bonus_attack_damage=bonus_attack_damage,
             bonus_armor=bonus_armor
             )
         return damage

--- a/champion.py
+++ b/champion.py
@@ -1,5 +1,8 @@
-from damage import damage_after_positive_resistance
-from data_parser import ALL_CHAMPION_BASE_STATS, SCALING_STAT_NAMES
+from typing import List
+
+import stats
+from damage import damage_after_positive_resistance, damage_auto_attack
+from data_parser import ALL_CHAMPION_BASE_STATS, SCALING_STAT_NAMES, ALL_ITEM_STATS
 
 
 # TODO: Might be a good opportunity to use abstract class for base champion
@@ -11,36 +14,61 @@ class BaseChampion:
         - auto attack
     """
 
-    def __init__(self, champion_name: str, level: int = 1):
+    def __init__(self, champion_name: str, level: int = 1, items: List[str] = None):
         assert isinstance(level, int) and 1 <= level <= 18, "Champion level should be in the [1,18] range"
         self.level = level
-        self.update_stat_from_level(ALL_CHAMPION_BASE_STATS[champion_name])
+        self.items = items
+        self.orig_base_stats = self.get_champion_base_stats(ALL_CHAMPION_BASE_STATS[champion_name])
+        self.item_stats = self.get_items_total_stats(items)
+        self.bonus_stats = self.get_bonus_stats()
 
-    def update_stat_from_level(self, champion_stats):
+    def get_champion_base_stats(self, champion_stats):
         """Takes all the base stats from the input dictionary and create the corresponding attributes in the instance"""
+        
+        return {stat_name: stats.calculate_stat_from_level(champion_stats, stat_name, self.level) for stat_name in SCALING_STAT_NAMES}
 
-        def calculate_flat_stat_from_level(base: float, mean_growth_perlevel: float, level: int):
-            """As described in league wiki: https://leagueoflegends.fandom.com/wiki/Champion_statistic#Growth_statistic_calculations"""
+    def get_items_total_stats(self, items):
+        """Sum the base stats of each item"""
+        if items is None:
+            return dict()
 
-            return base + mean_growth_perlevel * (level - 1) * (0.7025 + 0.0175 * (level - 1))
+        total_item_stats = dict()
+        for item_name in items:
+            item_stats =  ALL_ITEM_STATS[item_name]
+            self.update_bonus_stat_with_item(total_item_stats, item_stats)
 
-        def calculate_stat_from_level(base_stats: dict, stat_name: str, level: int):
-            """Flat scaling for all stats except for attack speed"""
-            stat = base_stats[stat_name]
-            mean_growth_perlevel = base_stats[stat_name + "_perlevel"]
-            if stat_name == "attack_speed":
-                # attack speed scaling is in % instead of flat. Base increase level 1 is considered to be 0 %.
-                percentage_increase = calculate_flat_stat_from_level(0, mean_growth_perlevel, level)
-                return stat * (1 + percentage_increase / 100)
-            return calculate_flat_stat_from_level(stat, mean_growth_perlevel, level)
+        return total_item_stats
 
-        for stat_name in SCALING_STAT_NAMES:
-            self.__dict__[stat_name] = calculate_stat_from_level(champion_stats, stat_name, self.level)
+    def update_bonus_stat_with_item(self, total_item_stats, item_stats):
+        """Update the base stats in the item stats dict with a new item."""
+        for stat_name, stat_value in item_stats.items():
+            if stat_name not in total_item_stats:
+                total_item_stats[stat_name] = stat_value
+            else:
+                total_item_stats[stat_name] += stat_value
+
+    def get_bonus_stats(self): # TODO: add runes
+        """Get bonus stats from all sources of bonus stats (items, runes)"""
+        if self.items is None:
+            return dict()
+        return self.item_stats.copy()
+
+    def equip_item(self, item_name):
+        self.update_bonus_stat_with_item(self.item_stats, ALL_ITEM_STATS[item_name])
+        self.bonus_stats = self.get_bonus_stats()
 
     def auto_attack(self, enemy_champion):
         """Calculates the damage dealt to an enemy champion with an autoattack"""
-        return damage_after_positive_resistance(self.attack_damage, enemy_champion.armor)
+        bonus_attack_damage = self.bonus_stats["attack_damage"] if "attack_damage" in self.bonus_stats else 0
+        bonus_armor = enemy_champion.bonus_stats["armor"] if "armor" in enemy_champion.bonus_stats else 0
 
+        damage = damage_auto_attack(
+            base_attack_damage=self.orig_base_stats["attack_damage"], 
+            bonus_attack_damage=bonus_attack_damage,
+            base_armor=enemy_champion.orig_base_stats["armor"],
+            bonus_armor=bonus_armor
+            )
+        return damage
 
 # Dummy class for tests in practice tool.
 class Dummy:

--- a/champion.py
+++ b/champion.py
@@ -5,13 +5,10 @@ from data_parser import ALL_CHAMPION_BASE_STATS, SCALING_STAT_NAMES
 # TODO: Might be a good opportunity to use abstract class for base champion
 class BaseChampion:
     """
-    Base class to represent a champion. It is initialized with level 1 stats and have traits shared
-    accross all champions:
-        - Base State
-        - Level up mechanism
-        - Equip item
+    Base class to represent a champion. It is initialized with the stats of a champion at a given level.
+    Some mechanisms are shared accross all champions:
+        - equip_item
         - auto attack
-        ...
     """
 
     def __init__(self, champion_name: str, level: int = 1):

--- a/champion.py
+++ b/champion.py
@@ -49,11 +49,9 @@ class Dummy:
         assert bonus_armor % 10 == 0
         assert health % 100 == 0
         assert health <= 10000
-        self.health = health
-        self.armor = 0
-        self.magic_resist = 0
-        self.bonus_armor = bonus_armor
-        self.bonus_magic_resist = bonus_magic_resist
+
+        self.orig_base_stats = {"armor": 0, "magic_resist": 0}
+        self.bonus_stats = {"health":health, "armor": bonus_armor, "magic_resist": bonus_magic_resist}
 
 
 # Each champion has its own class as their spells have different effects.

--- a/champion.py
+++ b/champion.py
@@ -20,7 +20,7 @@ class BaseChampion:
         self.items = items
         self.orig_base_stats = self.get_champion_base_stats(ALL_CHAMPION_BASE_STATS[champion_name])
         self.item_stats = self.get_items_total_stats(items)
-        self.bonus_stats = self.get_bonus_stats()
+        self.orig_bonus_stats = self.get_bonus_stats()
 
     def get_champion_base_stats(self, champion_stats):
         """Takes all the base stats from the input dictionary and create the corresponding attributes in the instance"""
@@ -56,12 +56,12 @@ class BaseChampion:
     def equip_item(self, item_name):
         self.items.append(item_name)
         self.update_bonus_stat_with_item(self.item_stats, ALL_ITEM_STATS[item_name])
-        self.bonus_stats = self.get_bonus_stats()
+        self.orig_bonus_stats = self.get_bonus_stats()
 
     def auto_attack(self, enemy_champion):
         """Calculates the damage dealt to an enemy champion with an autoattack"""
-        bonus_attack_damage = self.bonus_stats["attack_damage"] if "attack_damage" in self.bonus_stats else 0
-        bonus_armor = enemy_champion.bonus_stats["armor"] if "armor" in enemy_champion.bonus_stats else 0
+        bonus_attack_damage = self.orig_bonus_stats["attack_damage"] if "attack_damage" in self.orig_bonus_stats else 0
+        bonus_armor = enemy_champion.orig_bonus_stats["armor"] if "armor" in enemy_champion.orig_bonus_stats else 0
 
         damage = damage_auto_attack(
             base_attack_damage=self.orig_base_stats["attack_damage"], 
@@ -79,8 +79,15 @@ class Dummy:
         assert health % 100 == 0
         assert health <= 10000
 
-        self.orig_base_stats = {"armor": 0, "magic_resist": 0}
-        self.bonus_stats = {"health":health, "armor": bonus_armor, "magic_resist": bonus_magic_resist}
+        self.orig_base_stats = {
+            "armor": 0, 
+            "magic_resist": 0
+        }
+        self.orig_bonus_stats = {
+            "health": health, 
+            "armor": bonus_armor, 
+            "magic_resist": bonus_magic_resist
+        }
 
 
 # Each champion has its own class as their spells have different effects.

--- a/champion.py
+++ b/champion.py
@@ -24,7 +24,6 @@ class BaseChampion:
 
     def get_champion_base_stats(self, champion_stats):
         """Takes all the base stats from the input dictionary and create the corresponding attributes in the instance"""
-<<<<<<< HEAD
         
         return {stat_name: stats.calculate_stat_from_level(champion_stats, stat_name, self.level) for stat_name in SCALING_STAT_NAMES}
 
@@ -57,26 +56,6 @@ class BaseChampion:
     def equip_item(self, item_name):
         self.update_bonus_stat_with_item(self.item_stats, ALL_ITEM_STATS[item_name])
         self.bonus_stats = self.get_bonus_stats()
-=======
-
-        def calculate_flat_stat_from_level(base: float, mean_growth_perlevel: float, level: int):
-            """As described in league wiki: https://leagueoflegends.fandom.com/wiki/Champion_statistic#Growth_statistic_calculations"""
-
-            return base + mean_growth_perlevel * (level - 1) * (0.7025 + 0.0175 * (level - 1))
-
-        def calculate_stat_from_level(base_stats: dict, stat_name: str, level: int):
-            """Flat scaling for all stats except for attack speed"""
-            stat = base_stats[stat_name]
-            mean_growth_perlevel = base_stats[stat_name + "_perlevel"]
-            if stat_name == "attack_speed":
-                # attack speed scaling is in % instead of flat. Base increase level 1 is considered to be 0 %.
-                percentage_increase = calculate_flat_stat_from_level(0, mean_growth_perlevel, level)
-                return stat * (1 + percentage_increase / 100)
-            return calculate_flat_stat_from_level(stat, mean_growth_perlevel, level)
-
-        for stat_name in SCALING_STAT_NAMES:
-            setattr(self, stat_name, calculate_stat_from_level(champion_stats, stat_name, self.level))
->>>>>>> ba491692af7df647717c41983905dd6070e70b3b
 
     def auto_attack(self, enemy_champion):
         """Calculates the damage dealt to an enemy champion with an autoattack"""

--- a/damage.py
+++ b/damage.py
@@ -59,10 +59,20 @@ def physical_damage_after_armor(pre_mitigation_damage: float, lethality: float, 
         return damage_after_positive_resistance(pre_mitigation_damage, armor_eq)
 
 
-def damage_auto_attack(base_attack_damage: float, bonus_attack_damage: float, lethality: float, attacker_level: int,
-                       armor_pen_mult_factor: float, bonus_armor_pen_mult_factor: float, base_armor: float,
-                       bonus_armor: float, damage_modifier_flat: float, damage_modifier_percent_mult_factor: float,
-                       crit: 'bool', crit_damage: float):
+def damage_auto_attack(
+    base_attack_damage: float, 
+    bonus_attack_damage: float, 
+    base_armor: float, 
+    bonus_armor: float, 
+    attacker_level: int = 1, 
+    lethality: float = 0, 
+    armor_pen_mult_factor: float = 1, 
+    bonus_armor_pen_mult_factor: float = 1, 
+    damage_modifier_flat: float = 0, 
+    damage_modifier_percent_mult_factor: float = 1,
+    crit: bool = False, 
+    crit_damage: float = 0
+    ):
     """
     Calculates the output damage of crit/non-crit, empowered/modified/normal auto attacks
     The base armor and bonus armor of the champion being attacked should already take into account the flat or

--- a/damage.py
+++ b/damage.py
@@ -61,9 +61,9 @@ def physical_damage_after_armor(pre_mitigation_damage: float, lethality: float, 
 
 def damage_auto_attack(
     base_attack_damage: float, 
-    bonus_attack_damage: float, 
     base_armor: float, 
-    bonus_armor: float, 
+    bonus_attack_damage: float = 0, 
+    bonus_armor: float = 0, 
     attacker_level: int = 1, 
     lethality: float = 0, 
     armor_pen_mult_factor: float = 1, 

--- a/item.py
+++ b/item.py
@@ -31,5 +31,5 @@ class Sheen(BaseItem):
     def spellblade(self, owner_champion, enemy_champion):
         """Calculates the bonus damage dealt with an autoattack : 100% of base AD """
         if isinstance(enemy_champion, Dummy):
-            return damage_after_positive_resistance(owner_champion.orig_base_stats["attack_damage"], enemy_champion.bonus_stats["armor"])
-        return damage_after_positive_resistance(owner_champion.orig_base_stats["attack_damage"], enemy_champion.bonus_stats["armor"])
+            return damage_after_positive_resistance(owner_champion.orig_base_stats["attack_damage"], enemy_champion.orig_bonus_stats["armor"])
+        return damage_after_positive_resistance(owner_champion.orig_base_stats["attack_damage"], enemy_champion.orig_bonus_stats["armor"])

--- a/item.py
+++ b/item.py
@@ -2,8 +2,16 @@ from data_parser import ALL_ITEM_STATS
 
 
 class BaseItem:
+    """
+    Base class to represent an item. It is initialized with the base stats of the item.
+    Additional effects passive/active are handled in the children Champion specific classes.
+    """
     def __init__(self, item_name: str):
-        self.stats = ALL_ITEM_STATS[item_name]
+        self.update_stat(item_name)
+
+    def update_stat(self, item_name):
+        for stat_name, stat_value in ALL_ITEM_STATS[item_name].items():
+            setattr(self, stat_name, stat_value)
 
 
 class DoranBlade(BaseItem):

--- a/item.py
+++ b/item.py
@@ -8,12 +8,9 @@ class BaseItem:
     Additional effects passive/active are handled in the children Champion specific classes.
     """
     def __init__(self, item_name: str):
-<<<<<<< HEAD
         self.update_stat(item_name)
 
     def update_stat(self, item_name):
-=======
->>>>>>> ba491692af7df647717c41983905dd6070e70b3b
         for stat_name, stat_value in ALL_ITEM_STATS[item_name].items():
             setattr(self, stat_name, stat_value)
 
@@ -34,5 +31,5 @@ class Sheen(BaseItem):
     def spellblade(self, owner_champion, enemy_champion):
         """Calculates the bonus damage dealt with an autoattack : 100% of base AD """
         if isinstance(enemy_champion, Dummy):
-            return damage_after_positive_resistance(owner_champion.attack_damage, enemy_champion.bonus_armor)
-        return damage_after_positive_resistance(owner_champion.attack_damage, enemy_champion.armor)
+            return damage_after_positive_resistance(owner_champion.orig_base_stats["attack_damage"], enemy_champion.bonus_stats["armor"])
+        return damage_after_positive_resistance(owner_champion.orig_base_stats["attack_damage"], enemy_champion.bonus_stats["armor"])

--- a/stats.py
+++ b/stats.py
@@ -1,0 +1,15 @@
+
+def calculate_flat_stat_from_level(base: float, mean_growth_perlevel: float, level: int):
+    """As described in league wiki: https://leagueoflegends.fandom.com/wiki/Champion_statistic#Growth_statistic_calculations"""
+
+    return base + mean_growth_perlevel * (level - 1) * (0.7025 + 0.0175 * (level - 1))
+
+def calculate_stat_from_level(base_stats: dict, stat_name: str, level: int):
+    """Flat scaling for all stats except for attack speed"""
+    stat = base_stats[stat_name]
+    mean_growth_perlevel = base_stats[stat_name + "_perlevel"]
+    if stat_name == "attack_speed":
+        # attack speed scaling is in % instead of flat. Base increase level 1 is considered to be 0 %.
+        percentage_increase = calculate_flat_stat_from_level(0, mean_growth_perlevel, level)
+        return stat * (1 + percentage_increase / 100)
+    return calculate_flat_stat_from_level(stat, mean_growth_perlevel, level)

--- a/tests/test_champion.py
+++ b/tests/test_champion.py
@@ -1,6 +1,6 @@
 import math
 
-from champion import Ahri, Annie
+from champion import Ahri, Annie, Dummy
 
 
 def test_auto_attack_lvl1():
@@ -17,9 +17,9 @@ def test_ahri_stat_perlevel():
     attack_damage = []
     for i in range(1, 19):
         ahri = Ahri(level=i)
-        attack_damage.append(round(ahri.attack_damage))
-        health_point.append(math.ceil(ahri.health))
-        attack_speed.append(round(ahri.attack_speed, 3))
+        attack_damage.append(round(ahri.orig_base_stats["attack_damage"]))
+        health_point.append(math.ceil(ahri.orig_base_stats["health"]))
+        attack_speed.append(round(ahri.orig_base_stats["attack_speed"], 3))
 
     assert attack_speed == [
         0.668,
@@ -68,7 +68,7 @@ def test_ahri_stat_perlevel():
 
 def test_get_stats():
     annie = Annie(level=18)
-    stats_annie = annie.__dict__
+    stats_annie = annie.orig_base_stats
     stats_annie = {stat_name: round(stat, 2) for stat_name, stat in stats_annie.items()}
 
     assert stats_annie == {
@@ -81,5 +81,12 @@ def test_get_stats():
         "crit_chance": 0.0,
         "attack_damage": 95.05,
         "attack_speed": 0.71,
-        "level": 18,
     }
+
+def test_auto_attack_with_item_component():
+    items = ['Cloth Armor', 'Long Sword', 'Pickaxe', 'B. F. Sword'] 
+    ahri = Ahri(level=4, items=items)
+    dummy = Dummy(health=1000, bonus_armor=100, bonus_magic_resist=100)
+
+    assert ahri.bonus_stats ==  {'armor': 15, 'gold': 2825, 'attack_damage': 75}
+    assert round(ahri.auto_attack(dummy)) == 67

--- a/tests/test_champion.py
+++ b/tests/test_champion.py
@@ -88,5 +88,5 @@ def test_auto_attack_with_item_component():
     ahri = Ahri(level=4, items=items)
     dummy = Dummy(health=1000, bonus_armor=100, bonus_magic_resist=100)
 
-    assert ahri.bonus_stats ==  {'armor': 15, 'gold': 2825, 'attack_damage': 75}
+    assert ahri.orig_bonus_stats ==  {'armor': 15, 'gold': 2825, 'attack_damage': 75}
     assert round(ahri.auto_attack(dummy)) == 67

--- a/tests/test_champion.py
+++ b/tests/test_champion.py
@@ -86,7 +86,7 @@ def test_get_stats():
 def test_auto_attack_with_item_component():
     items = ['Cloth Armor', 'Long Sword', 'Pickaxe', 'B. F. Sword'] 
     ahri = Ahri(level=4, items=items)
-    dummy = Dummy(health=1000, bonus_armor=100, bonus_magic_resist=100)
+    dummy = Dummy(health=1000, bonus_resistance=100)
 
     assert ahri.orig_bonus_stats ==  {'armor': 15, 'gold': 2825, 'attack_damage': 75}
     assert round(ahri.auto_attack(dummy)) == 67

--- a/tests/test_damage.py
+++ b/tests/test_damage.py
@@ -13,51 +13,51 @@ def tests_normal_auto_attack_cait_dummy_60():
     # Caitlyn level 1 with a doran's blade
     # No headshot no crit
     assert round(damage_auto_attack(base_attack_damage=62, bonus_attack_damage=13.4, lethality=0, attacker_level=1,
-                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.armor,
-                                    bonus_armor=dummy_60.bonus_armor, damage_modifier_flat=0,
+                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
+                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=False, crit_damage=0)) == 47
     # Caitlyn level 11 with an infinity edge
     # No headshot no crit
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=75.4, lethality=0, attacker_level=11,
-                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.armor,
-                                    bonus_armor=dummy_60.bonus_armor, damage_modifier_flat=0,
+                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
+                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=False, crit_damage=0)) == 107
     # No headshot with crit
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=75.4, lethality=0, attacker_level=11,
-                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.armor,
-                                    bonus_armor=dummy_60.bonus_armor, damage_modifier_flat=0,
+                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
+                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=True, crit_damage=0)) == 187
     # Caitlyn level 11 with an infinity edge and a lord dominik's regards
     # No headshot no crit
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=105.4, lethality=0, attacker_level=11,
-                                    armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.armor,
-                                    bonus_armor=dummy_60.bonus_armor, damage_modifier_flat=0,
+                                    armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
+                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit= False, crit_damage=0)) == 141
     # No headshot with crit
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=105.4, lethality=0, attacker_level=11,
-                                    armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.armor,
-                                    bonus_armor=dummy_60.bonus_armor, damage_modifier_flat=0,
+                                    armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
+                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=True, crit_damage=0)) == 247
     # Caitlyn level 11 with a duskblade of draktharr (and cloak of agility for crits)
     # No headshot no crit no duskblade effect
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=65.4, lethality=18, attacker_level=11,
-                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.armor,
-                                    bonus_armor=dummy_60.bonus_armor, damage_modifier_flat=0,
+                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
+                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=False, crit_damage=0)) == 111
     # No headshot with crit no duskblade effect
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=65.4, lethality=18, attacker_level=11,
-                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.armor,
-                                    bonus_armor=dummy_60.bonus_armor, damage_modifier_flat=0,
+                                    armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
+                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=True, crit_damage=0)) == 194
     # Caitlyn level 11 with a duskblade of draktharr and lord dominik's regards
     # No headshot no crit no duskblade effect
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=95.4, lethality=18, attacker_level=11,
-                                    armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.armor,
-                                    bonus_armor=dummy_60.bonus_armor, damage_modifier_flat=0,
+                                    armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
+                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=False, crit_damage=0)) == 150
     # No headshot with crit no duskblade effect
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=95.4, lethality=18, attacker_level=11,
-                                    armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.armor,
-                                    bonus_armor=dummy_60.bonus_armor, damage_modifier_flat=0,
+                                    armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
+                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=True, crit_damage=0)) == 263
 

--- a/tests/test_damage.py
+++ b/tests/test_damage.py
@@ -9,7 +9,7 @@ def tests_normal_auto_attack_cait_dummy_60():
     different items against a dummy with 60 bonus armor and 60 bonus mr
     Caitlyn has one adaptive force rune which gives 5.4 attack damage
     """
-    dummy_60 = Dummy(1000, 60, 60)
+    dummy_60 = Dummy(health=1000, bonus_resistance=60)
     # Caitlyn level 1 with a doran's blade
     # No headshot no crit
     assert round(damage_auto_attack(base_attack_damage=62, bonus_attack_damage=13.4, lethality=0, attacker_level=1,

--- a/tests/test_damage.py
+++ b/tests/test_damage.py
@@ -14,50 +14,50 @@ def tests_normal_auto_attack_cait_dummy_60():
     # No headshot no crit
     assert round(damage_auto_attack(base_attack_damage=62, bonus_attack_damage=13.4, lethality=0, attacker_level=1,
                                     armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
-                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
+                                    bonus_armor=dummy_60.orig_bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=False, crit_damage=0)) == 47
     # Caitlyn level 11 with an infinity edge
     # No headshot no crit
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=75.4, lethality=0, attacker_level=11,
                                     armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
-                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
+                                    bonus_armor=dummy_60.orig_bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=False, crit_damage=0)) == 107
     # No headshot with crit
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=75.4, lethality=0, attacker_level=11,
                                     armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
-                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
+                                    bonus_armor=dummy_60.orig_bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=True, crit_damage=0)) == 187
     # Caitlyn level 11 with an infinity edge and a lord dominik's regards
     # No headshot no crit
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=105.4, lethality=0, attacker_level=11,
                                     armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
-                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
+                                    bonus_armor=dummy_60.orig_bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit= False, crit_damage=0)) == 141
     # No headshot with crit
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=105.4, lethality=0, attacker_level=11,
                                     armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
-                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
+                                    bonus_armor=dummy_60.orig_bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=True, crit_damage=0)) == 247
     # Caitlyn level 11 with a duskblade of draktharr (and cloak of agility for crits)
     # No headshot no crit no duskblade effect
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=65.4, lethality=18, attacker_level=11,
                                     armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
-                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
+                                    bonus_armor=dummy_60.orig_bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=False, crit_damage=0)) == 111
     # No headshot with crit no duskblade effect
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=65.4, lethality=18, attacker_level=11,
                                     armor_pen_mult_factor=1, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
-                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
+                                    bonus_armor=dummy_60.orig_bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=True, crit_damage=0)) == 194
     # Caitlyn level 11 with a duskblade of draktharr and lord dominik's regards
     # No headshot no crit no duskblade effect
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=95.4, lethality=18, attacker_level=11,
                                     armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
-                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
+                                    bonus_armor=dummy_60.orig_bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=False, crit_damage=0)) == 150
     # No headshot with crit no duskblade effect
     assert round(damage_auto_attack(base_attack_damage=95.345, bonus_attack_damage=95.4, lethality=18, attacker_level=11,
                                     armor_pen_mult_factor=0.7, bonus_armor_pen_mult_factor=1, base_armor=dummy_60.orig_base_stats["armor"],
-                                    bonus_armor=dummy_60.bonus_stats["armor"], damage_modifier_flat=0,
+                                    bonus_armor=dummy_60.orig_bonus_stats["armor"], damage_modifier_flat=0,
                                     damage_modifier_percent_mult_factor=1, crit=True, crit_damage=0)) == 263
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -10,12 +10,9 @@ from damage import damage_after_positive_resistance
 def test_DoranBlade():
     doranblade = DoranBlade()
     assert doranblade.__dict__ == {'attack_damage': 8, 'health': 80, "gold": 450}
-<<<<<<< HEAD
-=======
 
 def test_Sheen():
     sheen = Sheen()
     annie = Annie()
     dummy=Dummy(1000,50,50)
-    assert sheen.spellblade(annie, dummy) ==  damage_after_positive_resistance(annie.attack_damage, dummy.bonus_armor)
->>>>>>> ba491692af7df647717c41983905dd6070e70b3b
+    assert sheen.spellblade(annie, dummy) ==  damage_after_positive_resistance(annie.orig_base_stats["attack_damage"], dummy.bonus_stats["armor"])

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -14,5 +14,5 @@ def test_DoranBlade():
 def test_Sheen():
     sheen = Sheen()
     annie = Annie()
-    dummy=Dummy(1000,50,50)
+    dummy = Dummy(health=1000, bonus_resistance=50)
     assert sheen.spellblade(annie, dummy) ==  damage_after_positive_resistance(annie.orig_base_stats["attack_damage"], dummy.orig_bonus_stats["armor"])

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -15,4 +15,4 @@ def test_Sheen():
     sheen = Sheen()
     annie = Annie()
     dummy=Dummy(1000,50,50)
-    assert sheen.spellblade(annie, dummy) ==  damage_after_positive_resistance(annie.orig_base_stats["attack_damage"], dummy.bonus_stats["armor"])
+    assert sheen.spellblade(annie, dummy) ==  damage_after_positive_resistance(annie.orig_base_stats["attack_damage"], dummy.orig_bonus_stats["armor"])

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -5,5 +5,4 @@ from item import DoranBlade
 
 def test_DoranBlade():
     doranblade = DoranBlade()
-    assert doranblade.stats == {'attack_damage': 8, 'health': 80, "gold": 450}
-
+    assert doranblade.__dict__ == {'attack_damage': 8, 'health': 80, "gold": 450}


### PR DESCRIPTION
My proposal for item handling 

- Change champion stats structure. All stats have same name defined in glossary.
```
self.orig_base_stats --> for basic champion stats
self.item_stats --> for item stats
self.orig_bonus_stat --> for bonus stats (item + runes)
```
- Can init a champion with a list of items defined in ALL_ITEM_STATS
- can equip dynamically an item with `equip_item`
- I tested ahri lvl 4 with cloth armor, pick axe, long sword, bf autoattack a dummy (see tests/test_champion.py)

I believe we can improve this solution by creating a Stat class and creating a magic method __add__ so we could add stat class between them like `self.bonus_stats = self.item_stats + self.rune_stats`

Still need to test auto attack with a setup with armor pen, letha etc 