### PR TITLE
Refactor spells

### DIFF
--- a/tests/champions/test_caitlyn.py
+++ b/tests/champions/test_caitlyn.py
@@ -33,26 +33,33 @@ def test_auto_attack():
 
 def q_default_run(inventory, enemy_champion, test_values):
     for spell_level in range(1, 6):
-        caitlyn = Caitlyn(level=2*spell_level-1, inventory=inventory)  # for levels 1, 3, 5, 7, 9
-        assert round(caitlyn.spell_q(spell_level, enemy_champion)) == test_values[spell_level-1]
+        caitlyn = Caitlyn(level=2*spell_level-1, inventory=inventory, spell_levels=[spell_level,1,1,1])  # for levels 1, 3, 5, 7, 9
+        assert round(caitlyn.spell_q.hit_damage(enemy_champion)) == test_values[spell_level-1]
 
 
 def test_q():
     q_default_run([LongSword()], Dummy(1000, 30), [108, 156, 206, 259, 315])
 
+def test_w_level_1():
+    # W has no damage, but we call hit_damage to trigger the on-hit effect
+    dummy = Dummy(1000, 30)
+    caitlyn = Caitlyn(level=1)
+    assert round(caitlyn.auto_attack_damage(dummy, False)) == 48
+    caitlyn.spell_w.hit_damage(dummy)
+    assert round(caitlyn.auto_attack_damage(dummy, False)) == 107
 
 def w_default_run(inventory, enemy_champion, test_values):
     for spell_level in range(1, 5):
-        caitlyn = Caitlyn(level=2*spell_level-1, inventory=inventory)  # for levels 1, 3, 5, 7
-        caitlyn.spell_w(level=spell_level)
+        caitlyn = Caitlyn(level=2*spell_level-1, spell_levels=[1,spell_level,1,1], inventory=inventory)  # for levels 1, 3, 5, 7, 9
+        caitlyn.spell_w.hit_damage(enemy_champion)
         assert round(caitlyn.auto_attack_damage(enemy_champion, False)) == test_values[2*spell_level-2]
-        caitlyn.spell_w(level=spell_level)
+        caitlyn.spell_w.hit_damage(enemy_champion)
         assert round(caitlyn.auto_attack_damage(enemy_champion, True)) == test_values[2*spell_level-1]
     # last test with lvl 13 for robustness with headshot dmg lvl scaling
-    caitlyn = Caitlyn(level=13, inventory=inventory)
-    caitlyn.spell_w(level=5)
+    caitlyn = Caitlyn(level=13, spell_levels=[1,5,1,1], inventory=inventory)
+    caitlyn.spell_w.hit_damage(enemy_champion)
     assert round(caitlyn.auto_attack_damage(enemy_champion, False)) == test_values[8]
-    caitlyn.spell_w(level=5)
+    caitlyn.spell_w.hit_damage(enemy_champion)
     assert round(caitlyn.auto_attack_damage(enemy_champion, True)) == test_values[9]
 
 
@@ -62,10 +69,10 @@ def test_w():
 
 def e_default_run(inventory, enemy_champion, test_values_e, test_values_empowered_auto_attack):
     for spell_level in range(1, 6):
-        caitlyn = Caitlyn(level=2*spell_level-1, inventory=inventory)  # for levels 1, 3, 5, 7, 9
-        assert round(caitlyn.spell_e(level=spell_level, enemy_champion=enemy_champion)) == test_values_e[spell_level-1]
+        caitlyn = Caitlyn(level=2*spell_level-1, inventory=inventory, spell_levels=[1,1,spell_level,1])  # for levels 1, 3, 5, 7, 9
+        assert round(caitlyn.spell_e.hit_damage(enemy_champion)) == test_values_e[spell_level-1]
         assert round(caitlyn.auto_attack_damage(enemy_champion, False)) == test_values_empowered_auto_attack[2*spell_level-2]
-        caitlyn.spell_e(level=spell_level, enemy_champion=enemy_champion)
+        caitlyn.spell_e.hit_damage(enemy_champion)
         assert round(caitlyn.auto_attack_damage(enemy_champion, True)) == test_values_empowered_auto_attack[2*spell_level-1]
 
 
@@ -75,8 +82,8 @@ def test_e():
 
 def r_default_run(inventory, enemy_champion, test_values):
     for spell_level in range(1, 4):
-        caitlyn = Caitlyn(level=spell_level*5+1, inventory=inventory)  # for levels 6, 11, 16
-        assert round(caitlyn.spell_r(level=spell_level, enemy_champion=enemy_champion)) == test_values[spell_level-1]
+        caitlyn = Caitlyn(level=spell_level*5+1, spell_levels=[1,1,1,spell_level], inventory=inventory)  # for levels 6, 11, 16
+        assert round(caitlyn.spell_r.hit_damage(enemy_champion)) == test_values[spell_level-1]
 
 
 def test_r():
@@ -95,8 +102,8 @@ def test_passive_w_e_interaction():
     caitlyn.auto_attack_count = 6
     # W and E should empower the next autoattack without consuming stacks
     # If cait uses W and E (regardless of the order), the first autoattack will always apply the W additional damage
-    caitlyn.spell_w(level=1)
-    caitlyn.spell_e(level=1, enemy_champion=dummy)
+    caitlyn.spell_w.hit_damage(dummy)
+    caitlyn.spell_e.hit_damage(dummy)
     assert round(caitlyn.auto_attack_damage(dummy, False)) == 117
     assert caitlyn.auto_attack_count == 6
     assert round(caitlyn.auto_attack_damage(dummy, False)) == 85
@@ -104,8 +111,8 @@ def test_passive_w_e_interaction():
     assert round(caitlyn.auto_attack_damage(dummy, False)) == 85
     assert caitlyn.auto_attack_count == 0
     caitlyn.auto_attack_count = 6
-    caitlyn.spell_e(level=1, enemy_champion=dummy)
-    caitlyn.spell_w(level=1)
+    caitlyn.spell_e.hit_damage(dummy)
+    caitlyn.spell_w.hit_damage(dummy)
     assert round(caitlyn.auto_attack_damage(dummy, False)) == 117
     assert caitlyn.auto_attack_count == 6
     assert round(caitlyn.auto_attack_damage(dummy, False)) == 85

--- a/tests/champions/test_malphite.py
+++ b/tests/champions/test_malphite.py
@@ -6,27 +6,27 @@ from tootanky.item import ALL_ITEM_CLASSES, BlastingWand, AmplifyingTome, Needle
 from tootanky.stats import Stats
 
 def test_malphite_q():
-    malph = Malphite(level=13)
+    malph = Malphite(level=13, spell_levels=[5,1,1,1])
     dummy = Dummy(health=1000, bonus_resistance=30)
     malph.equip_item(item=BlastingWand())
     malph.equip_item(item=AmplifyingTome())
-    dmg = malph.spell_q(level=5, enemy_champion=dummy)
+    dmg = malph.spell_q.hit_damage(dummy)
 
     assert round(dmg, 2) == 235.38
 
 def test_malphite_r():
-    malph = Malphite(level=11)
+    malph = Malphite(level=11, spell_levels=[1,1,1,2])
     dummy = Dummy(health=1000, bonus_resistance=30)
     malph.equip_item(item=NeedlesslyLargeRod())
-    dmg = malph.spell_r(level=2, enemy_champion=dummy)
-    malph.r.print_specs()
+    dmg = malph.spell_r.hit_damage(dummy)
+    malph.spell_r.print_specs()
 
     assert round(dmg, 2) == 272.31
 
 def test_malphite_e():
-    malph = Malphite(level=9)
+    malph = Malphite(level=9, spell_levels=[1,1,5,1])
     dummy = Dummy(health=1000, bonus_resistance=30)
     #malph.equip_item(item=NeedlesslyLargeRod())
-    dmg = malph.spell_e(level=5, enemy_champion=dummy)
+    dmg = malph.spell_e.hit_damage(dummy)
 
     assert round(dmg, 2) == 170.08

--- a/tests/champions/test_orianna.py
+++ b/tests/champions/test_orianna.py
@@ -4,9 +4,9 @@ from tootanky.item import BlastingWand
 
 
 def test_orianna_r():
-    orianna = Orianna(level=17)
+    orianna = Orianna(level=17, spell_levels=[1, 1, 1, 3])
     dummy = Dummy(health=1000, bonus_resistance=30)
     orianna.equip_item(item=BlastingWand())
-    dmg = orianna.spell_r(level=3, enemy_champion=dummy)
+    dmg = orianna.spell_r.hit_damage(dummy)
 
     assert round(dmg, 2) == 293.85

--- a/tests/champions/test_xerath.py
+++ b/tests/champions/test_xerath.py
@@ -5,32 +5,32 @@ from tootanky.item import BlastingWand
 
 def test_dummy_0_res():
     dummy = Dummy(1000, 0)
-    xerath = Xerath(level=18)
-    assert round(xerath.spell_q(1, dummy)) == 70
+    xerath = Xerath(level=18, spell_levels=[1,1,1,1])
+    assert round(xerath.spell_q.hit_damage(dummy)) == 70
 
     xerath.equip_item(BlastingWand())
     damage_per_level = [104, 144, 184, 224, 264]
     for spell_level in range(1, 6):
-        assert round(xerath.spell_q(spell_level, dummy)) == damage_per_level[spell_level - 1]
+        xerath.spell_q.set_level(spell_level)
+        assert round(xerath.spell_q.hit_damage(dummy)) == damage_per_level[spell_level - 1]
 
+dummy = Dummy(1000, 30)
+xerath = Xerath(level=16, inventory=[BlastingWand()])  # since xerath damage doesn't scale with his level we can fix his level
 
-def test_dummy_30_res():
-    dummy = Dummy(1000, 30)
-    q_test_values = [80, 111, 142, 172, 203]
-    w_test_values = [65, 108, 92, 153, 118, 197, 145, 242, 172, 287]
-    e_test_values = [75, 98, 122, 145, 168]
-    r_test_values = [168, 206, 245]
-    xerath = Xerath(level=16, inventory=[BlastingWand()])  # since xerath damage doesn't scale with his level we can fix his level
-    for spell_level in range(1, 6):
-        assert round(xerath.spell_q(spell_level, dummy)) == q_test_values[spell_level-1]
-        assert round(xerath.spell_w(spell_level, dummy, False)) == w_test_values[2*spell_level-2]
-        assert round(xerath.spell_w(spell_level, dummy, True)) == w_test_values[2*spell_level-1]
-        assert round(xerath.spell_e(spell_level, dummy)) == e_test_values[spell_level - 1]
-    r_exact_values = []
-    for spell_level in range(1, 4):
-        r_exact_value = xerath.spell_r(spell_level, dummy, 1)
-        assert round(r_exact_value) == r_test_values[spell_level-1]
-        r_exact_values.append(r_exact_value)
-    for spell_level in range(1, 4):
-        for i in range(0, spell_level + 3):
-            assert round(xerath.spell_r(spell_level, dummy, i)) == round(i * r_exact_values[spell_level-1])
+def make_test_spell(spell, values, **kwargs):
+    for spell_level in range(1,len(values)+1):
+        spell.set_level(spell_level)
+        assert round(spell.hit_damage(dummy, **kwargs)) == values[spell_level-1]
+
+def test_xerath_q():
+    make_test_spell(xerath.spell_q, [80, 111, 142, 172, 203])
+
+def test_xerath_w():
+    make_test_spell(xerath.spell_w, [65, 92, 118, 145, 172], is_empowered=False)
+    make_test_spell(xerath.spell_w, [108, 153, 197, 242, 287], is_empowered=True)
+
+def test_xerath_e():
+    make_test_spell(xerath.spell_e, [75, 98, 122, 145, 168])
+
+def test_xerath_r():
+    make_test_spell(xerath.spell_r, [168, 206, 245])

--- a/tests/test_champion.py
+++ b/tests/test_champion.py
@@ -85,10 +85,10 @@ def test_get_stats():
 
 
 def test_annie_q():
-    annie = Annie(level=17)
+    annie = Annie(level=17, spell_levels=[5,5,5,5])
     dummy = Dummy(health=1000, bonus_resistance=30)
     annie.equip_item(item=BlastingWand())
-    dmg = annie.spell_q(level=5, enemy_champion=dummy)
+    dmg = annie.spell_q.hit_damage(dummy)
 
     assert round(dmg, 2) == 193.85
 

--- a/tootanky/champions/annie.py
+++ b/tootanky/champions/annie.py
@@ -7,23 +7,22 @@ class Annie(BaseChampion):
     def __init__(self, **kwargs):
         super().__init__(champion_name=__class__.champion_name, **kwargs)
 
-    def spell_q(self, level, enemy_champion):
-        self.q = QAnnie(level=level)
-        return self.spell_damage(spell=self.q, enemy_champion=enemy_champion)
+    def init_spells(self, spell_levels):
+        level_q, level_w, level_e, level_r = spell_levels
+        self.spell_q = QAnnie(self, level_q)
+
    
 class QAnnie(BaseSpell):
     champion_name = "Annie"
     spell_key = "q"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)        
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [80, 115, 150, 185, 220]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.8] 
         # ["target_ability_power", "base_armor", "target_bonus_health"] add prefix target ?
-        self.ratio_stats = ["ability_power"] 
+        self.ratios = [("ability_power", 0.8)]
     

--- a/tootanky/champions/caitlyn.py
+++ b/tootanky/champions/caitlyn.py
@@ -17,6 +17,13 @@ class Caitlyn(BaseChampion):
             self.passive_multiplier = 0.9
         if 13 <= self.level <= 18:
             self.passive_multiplier = 1.2
+    
+    def init_spells(self, spell_levels):
+        [level_q, level_w, level_e, level_r] = spell_levels
+        self.spell_q = QCaitlyn(self, level_q)
+        self.spell_w = WCaitlyn(self, level_w)
+        self.spell_e = ECaitlyn(self, level_e)
+        self.spell_r = RCaitlyn(self, level_r)
 
     def auto_attack_damage(self, enemy_champion, is_crit: bool = False):
         base_attack_damage = self.base_attack_damage
@@ -33,10 +40,8 @@ class Caitlyn(BaseChampion):
         std_headshot_dmg = attack_damage * (self.passive_multiplier + 1.3125 * crit_chance)
 
         if self.w_hit:
-            damage_modifier_flat = (
-                std_headshot_dmg + self.w.base_spell_damage + 
-                self.w.bonus_attack_damage_ratio * bonus_attack_damage
-            )
+            bonus_flat, bonus_ratio = self.spell_w.get_headshot_bonus_damage()
+            damage_modifier_flat = std_headshot_dmg + bonus_flat + bonus_ratio * bonus_attack_damage
             self.w_hit = False
         else:
             if self.e_hit:
@@ -64,98 +69,75 @@ class Caitlyn(BaseChampion):
         )
         return damage
 
-    def spell_q(self, level, enemy_champion):
-        self.q = QCaitlyn(level=level)
-
-        return self.spell_damage(spell=self.q, enemy_champion=enemy_champion)
-
-
-    def spell_w(self, level):
-        self.w = WCaitlyn(level=level)
-        self.w_hit = True
-
-    def spell_e(self, level, enemy_champion):
-        self.e = ECaitlyn(level=level)
-        self.e_hit = True
-
-        return self.spell_damage(spell=self.e, enemy_champion=enemy_champion)
-
-
-    def spell_r(self, level, enemy_champion):
-        self.r = RCaitlyn(level=level)
-
-        damage_modifier_flat = self.r.bonus_attack_damage_ratio * self.bonus_attack_damage
-
-        post_mtg_dmg = self.spell_damage(
-            spell=self.r, 
-            enemy_champion=enemy_champion, 
-            damage_modifier_flat=damage_modifier_flat
-        )
-
-        return post_mtg_dmg * (1 + self.bonus_crit_chance * 0.25)
-
 
 class QCaitlyn(BaseSpell):
     champion_name = "Caitlyn"
     spell_key = "q"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)
         self.damage_type = "physical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [50, 90, 130, 170, 210]
         self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratio_per_level = [1.25, 1.45, 1.65, 1.85, 2.05]
-        self.ratios = [self.ratio_per_level[level - 1]]
-        self.ratio_stats = ["attack_damage"]
+        self.ratios = [("attack_damage", [1.25, 1.45, 1.65, 1.85, 2.05])]
 
+    def get_ratio_per_level(self):
+        return self.ratio_per_level[self.level - 1]
 
 class WCaitlyn(BaseSpell):
     champion_name = "Caitlyn"
     spell_key = "w"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)
         self.damage_type = "physical"
         self.target_res_type = self.get_resistance_type()
-        self.base_damage_per_level = [40, 85, 130, 175, 220]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratio_per_level = [0.4, 0.5, 0.6, 0.7, 0.8]
-        self.bonus_attack_damage_ratio = self.ratio_per_level[level-1]
+        self.base_damage_per_level = [0, 0, 0, 0, 0]
+        self.headshot_bonus_damage_flat = [40, 85, 130, 175, 220]
+        self.headshot_bonus_damage_ratio = [0.4, 0.5, 0.6, 0.7, 0.8]
+
+    def get_headshot_bonus_damage(self):
+        flat = self.headshot_bonus_damage_flat[self.level - 1]
+        ratio = self.headshot_bonus_damage_ratio[self.level - 1]
+        return flat, ratio
+
+    def on_hit_effect(self, target):
+        self.champion.w_hit = True
 
 
 class ECaitlyn(BaseSpell):
     champion_name = "Caitlyn"
     spell_key = "e"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [80, 130, 180, 230, 280]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.8]
-        self.ratio_stats = ["ability_power"]
+        self.ratios = [("ability_power", 0.8)]
 
+    def on_hit_effect(self, target):
+        self.champion.e_hit = True
 
 class RCaitlyn(BaseSpell):
     champion_name = "Caitlyn"
     spell_key = "r"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)        
         self.damage_type = "physical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [300, 525, 750]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.bonus_attack_damage_ratio = 2
-        self.ratios = []
-        self.ratio_stats = []
+        self.ratios = [("bonus_attack_damage", 2)]
+
+    def get_damage_modifier_ratio(self):
+        return 1 + self.champion.bonus_crit_chance / 4

--- a/tootanky/champions/malphite.py
+++ b/tootanky/champions/malphite.py
@@ -7,65 +7,47 @@ class Malphite(BaseChampion):
     def __init__(self, **kwargs):
         super().__init__(champion_name=__class__.champion_name, **kwargs)
 
-    def spell_q(self, level, enemy_champion):
-        self.q = QMalphite(level=level)
+    def init_spells(self, spell_levels):
+        level_q, level_w, level_e, level_r = spell_levels
+        self.spell_q = QMalphite(self, level_q)
+        self.spell_e = EMalphite(self, level_e)
+        self.spell_r = RMalphite(self, level_r)
 
-        return self.spell_damage(spell=self.q, enemy_champion=enemy_champion)
-
-    def spell_e(self, level, enemy_champion):
-        self.e = EMalphite(level=level)
-
-        return self.spell_damage(spell=self.e, enemy_champion=enemy_champion)
-
-    
-    def spell_r(self, level, enemy_champion):
-        self.r = RMalphite(level=level)
-
-        return self.spell_damage(spell=self.r, enemy_champion=enemy_champion)
-
-   
 class QMalphite(BaseSpell):
     champion_name = "Malphite"
     spell_key = "q"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)        
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [70, 120, 170, 220, 270]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.6]
-        self.ratio_stats = ["ability_power"]
+        self.ratios = [("ability_power", 0.6)]
 
 class EMalphite(BaseSpell):
     champion_name = "Malphite"
     spell_key = "e"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)        
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [60, 95, 130, 165, 200]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.9, 0.3]
-        self.ratio_stats = ["ability_power", "armor"]
+        self.ratios = [("ability_power", 0.9), ("armor", 0.3)]
 
 class RMalphite(BaseSpell):
     champion_name = "Malphite"
     spell_key = "r"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)        
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [200, 300, 400]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.9]
-        self.ratio_stats = ["ability_power"]
-        
+        self.ratios = [("ability_power", 0.9)]

--- a/tootanky/champions/orianna.py
+++ b/tootanky/champions/orianna.py
@@ -9,23 +9,20 @@ class Orianna(BaseChampion):
     def __init__(self, **kwargs):
         super().__init__(champion_name=__class__.champion_name, **kwargs)
 
-    def spell_r(self, level, enemy_champion):
-        self.r = ROrianna(level=level)
-
-        return self.spell_damage(spell=self.r, enemy_champion=enemy_champion)
+    def init_spells(self, spell_levels):
+        level_q, level_w, level_e, level_r = spell_levels
+        self.spell_r = ROrianna(self, level_r)
 
 
 class ROrianna(BaseSpell):
     champion_name = "Orianna"
     spell_key = "r"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [200, 275, 350]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.8]
-        self.ratio_stats = ["ability_power"]
+        self.ratios = [("ability_power", 0.8)]

--- a/tootanky/champions/xerath.py
+++ b/tootanky/champions/xerath.py
@@ -8,88 +8,67 @@ class Xerath(BaseChampion):
     def __init__(self, **kwargs):
         super().__init__(champion_name=__class__.champion_name, **kwargs)
 
-    def spell_q(self, level, enemy_champion):
-        self.q = QXerath(level=level)
-
-        return self.spell_damage(spell=self.q, enemy_champion=enemy_champion)
-
-    def spell_w(self, level: int, enemy_champion: BaseChampion, is_empowered: bool):
-        self.w = WXerath(level=level)
-
-        post_mtg_dmg = self.spell_damage(spell=self.w, enemy_champion=enemy_champion)
-
-        if not is_empowered:
-            return post_mtg_dmg
-        else:
-            return post_mtg_dmg * 1.667
-
-    def spell_e(self, level, enemy_champion):
-        self.e = EXerath(level=level)
-
-        return self.spell_damage(spell=self.e, enemy_champion=enemy_champion)
-
-
-    def spell_r(self, level: int, enemy_champion: BaseChampion, nb_hit):
-        self.r = RXerath(level=level)
-        assert 0 <= nb_hit <= self.r.recast_per_level[level-1]
-
-        post_mtg_dmg = self.spell_damage(spell=self.r, enemy_champion=enemy_champion)
-
-        return post_mtg_dmg * nb_hit
+    def init_spells(self, spell_levels):
+        level_q, level_w, level_e, level_r = spell_levels
+        self.spell_q = QXerath(self, level_q)
+        self.spell_w = WXerath(self, level_w)
+        self.spell_e = EXerath(self, level_e)
+        self.spell_r = RXerath(self, level_r)
 
 
 class QXerath(BaseSpell):
     champion_name = "Xerath"
     spell_key = "q"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [70, 110, 150, 190, 230]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.85]
-        self.ratio_stats = ["ability_power"]
+        self.ratios = [("ability_power", 0.85)]
 
+    def init_per_level(self, level):
+        self.base_spell_damage = self.base_damage_per_level[level - 1]
 
 class WXerath(BaseSpell):
     champion_name = "Xerath"
     spell_key = "w"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [60, 95, 130, 165, 200]
         self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.6]
-        self.ratio_stats = ["ability_power"]
+        self.ratios = [("ability_power", 0.6)]
+
+    def get_damage_modifier_ratio(self, is_empowered = True):
+        return 1.667 if is_empowered else 1
 
 class EXerath(BaseSpell):
     champion_name = "Xerath"
     spell_key = "e"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [80, 110, 140, 170, 200]
         self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.45]
-        self.ratio_stats = ["ability_power"]
+        self.ratios = [("ability_power", 0.45)]
 
 class RXerath(BaseSpell):
     champion_name = "Xerath"
     spell_key = "r"
 
-    def __init__(self, level):
-        super().__init__(champion_name=__class__.champion_name, spell_key=__class__.spell_key, level=level)
+    def __init__(self, champion, level):
+        super().__init__(champion, spell_key=__class__.spell_key, level=level)
 
         self.nature = self.get_spell_nature(self.spell_key)
         self.damage_type = "magical"
@@ -97,5 +76,10 @@ class RXerath(BaseSpell):
         self.base_damage_per_level = [200, 250, 300]
         self.recast_per_level = [3, 4, 5]
         self.base_spell_damage = self.base_damage_per_level[level - 1]
-        self.ratios = [0.45]
-        self.ratio_stats = ["ability_power"]
+        self.ratios = [("ability_power", 0.45)]
+
+    def get_damage_modifer_ratio(self, target: BaseChampion, nb_hit = None):
+        if nb_hit is None:
+            raise ValueError("nb_hit must be specified for Xerath R")
+        assert 0 <= nb_hit <= self.r.recast_per_level[self.level-1]
+        return nb_hit

--- a/tootanky/damage.py
+++ b/tootanky/damage.py
@@ -29,18 +29,15 @@ def pre_mitigation_spell_damage(
     base_spell_damage: float,
     ratio_damage: float, 
     damage_modifier_flat: float = 0,
-    damage_modifier_percent: float = 0,
+    damage_modifier_ratio: float = 0,
 ):
     """
     Calculates the pre-mitigation damage of a spell or an autoattack
     All values regarding damage modifiers should include the buffs/debuffs coming from spells, summoner spells, or items
     from both the attacker AND the defender.
-    :param: ratio_damage is calculated using ratio_damage_from_list
+    :param: ratio_damage is damage that scales with the champion's or target's stat
     """
-
-    dmg_mod_perc_multiplier = 1 - damage_modifier_percent / 100
-
-    return (base_spell_damage + ratio_damage + damage_modifier_flat) * dmg_mod_perc_multiplier
+    return (base_spell_damage + ratio_damage + damage_modifier_flat) * damage_modifier_ratio
 
 def avg_pre_mitigation_auto_attack_damage(
     base_attack_damage: float,

--- a/tootanky/spell.py
+++ b/tootanky/spell.py
@@ -1,5 +1,5 @@
 from tootanky.data_parser import ALL_CHAMPION_SPELLS
-
+from tootanky.damage import pre_mitigation_spell_damage, damage_after_resistance
 
 class BaseSpell:
     """
@@ -15,17 +15,15 @@ class BaseSpell:
     Not all spell specifications are included in the data file which means there is a need to double check
     the current specs + add the missing ones inside the subclass of BaseSpell.
     """
-    def __init__(self, champion_name, spell_key, level):
-        self.champion_name = champion_name
+    def __init__(self, champion, spell_key, level=1):
+        self.champion = champion
         self.spell_key = spell_key
-        self.spell_specs = ALL_CHAMPION_SPELLS[champion_name][spell_key].copy()
+        self.spell_specs = ALL_CHAMPION_SPELLS[champion.champion_name][spell_key].copy()
         for name, value in self.spell_specs.items():
             setattr(self, name, value)
+        self.ratios = []
 
-        self.level = level
-        self.range = self.range[level - 1]
-        self.cost = self.cost[level - 1]
-        self.cooldown = self.cooldown[level - 1]
+        self.set_level(level)
         self.damage_type = None
 
     @staticmethod
@@ -54,3 +52,70 @@ class BaseSpell:
     def print_orig_specs(self):
         """pretty print the stats"""
         return print("\n".join([f"{k}: {v}" for k, v in self.spell_specs.items()]))
+
+    def set_level(self, level):
+        """Set spell level"""
+        self.level = level
+
+    def get_base_damage(self):
+        """Get the base damage of a spell"""
+        return self.base_damage_per_level[self.level - 1]
+
+    def ratio_damage(self, target) -> float:
+        """Get the damage dealt by the ratio part of a spell, taking into account multiple ratios"""
+        damage = 0
+        for stat_name, ratio in self.ratios:
+            if "target_" in stat_name:
+                stat_value = getattr(target, stat_name.replace("target_", ""))
+            else:
+                stat_value = getattr(self.champion, stat_name)
+            if isinstance(ratio, list):
+                ratio = ratio[self.level - 1]
+            damage += stat_value * ratio
+        return damage
+
+    def damage(self, target, damage_modifier_flat=0, damage_modifier_ratio=1) -> float:
+        """Calculates the damage dealt to a champion with a spell"""
+
+        ratio_damage = self.ratio_damage(target)
+        
+        pre_mtg_dmg = pre_mitigation_spell_damage(
+            self.get_base_damage(),
+            ratio_damage,
+            damage_modifier_flat=damage_modifier_flat,
+            damage_modifier_ratio=damage_modifier_ratio
+        )
+
+        res_type = self.target_res_type
+        if res_type == "armor":
+            bonus_resistance_pen = self.champion.bonus_armor_pen_percent
+        else:
+            bonus_resistance_pen = 0
+        # TODO: Can be refactored once we know more about bonus res pen    
+        post_mtg_dmg = damage_after_resistance(
+            pre_mitigation_damage=pre_mtg_dmg,
+            base_resistance=getattr(target, f"base_{res_type}"),
+            bonus_resistance=getattr(target, f"bonus_{res_type}"),
+            flat_resistance_pen=getattr(self.champion, f"{res_type}_pen_flat"),
+            resistance_pen=getattr(self.champion, f"{res_type}_pen_percent"),
+            bonus_resistance_pen=bonus_resistance_pen
+        )
+
+        return post_mtg_dmg
+
+    def get_damage_modifier_flat(self, **kwargs):
+        return 0
+
+    def get_damage_modifier_ratio(self, **kwargs):
+        return 1
+
+    def on_hit_effect(self, target, **kwargs):
+        """Effect on hit"""
+        pass
+
+    def hit_damage(self, target, **kwargs):
+        damage_modifier_flat = self.get_damage_modifier_flat(**kwargs)
+        damage_modifier_ratio = self.get_damage_modifier_ratio(**kwargs)
+        damage = self.damage(target, damage_modifier_flat, damage_modifier_ratio)
+        self.on_hit_effect(target, **kwargs) # Be sure to compute the damage before the effect
+        return damage


### PR DESCRIPTION
(Need to fix tests)

Refactor the handling of spells so that they can be defined completely in each spell's class instead of in the champion's `spell_[qwer]()` methods, and make Caitlyn's spells follow a more standard structure.

Also `enemy_champion` should be renamed more generally to `target`