### PR TITLE
Remove equip item and unequip item, fix tests

### DIFF
--- a/tests/champions/test_malphite.py
+++ b/tests/champions/test_malphite.py
@@ -4,19 +4,16 @@ from tootanky.item import AmplifyingTome, BlastingWand, NeedlesslyLargeRod
 
 
 def test_malphite_q():
-    malph = Malphite(level=13, spell_levels=[5, 1, 1, 1])
+    malph = Malphite(level=13, inventory=[BlastingWand(), AmplifyingTome()], spell_levels=[5, 1, 1, 1])
     dummy = Dummy(health=1000, bonus_resistance=30)
-    malph.equip_item(item=BlastingWand())
-    malph.equip_item(item=AmplifyingTome())
     dmg = malph.spell_q.hit_damage(dummy)
 
     assert round(dmg, 2) == 235.38
 
 
 def test_malphite_r():
-    malph = Malphite(level=11, spell_levels=[1, 1, 1, 2])
+    malph = Malphite(level=11, inventory=[NeedlesslyLargeRod()], spell_levels=[1, 1, 1, 2])
     dummy = Dummy(health=1000, bonus_resistance=30)
-    malph.equip_item(item=NeedlesslyLargeRod())
     dmg = malph.spell_r.hit_damage(dummy)
     malph.spell_r.print_specs()
 
@@ -26,7 +23,6 @@ def test_malphite_r():
 def test_malphite_e():
     malph = Malphite(level=9, spell_levels=[1, 1, 5, 1])
     dummy = Dummy(health=1000, bonus_resistance=30)
-    # malph.equip_item(item=NeedlesslyLargeRod())
     dmg = malph.spell_e.hit_damage(dummy)
 
     assert round(dmg, 2) == 170.08

--- a/tests/champions/test_orianna.py
+++ b/tests/champions/test_orianna.py
@@ -4,9 +4,8 @@ from tootanky.item import BlastingWand
 
 
 def test_orianna_r():
-    orianna = Orianna(level=17, spell_levels=[1, 1, 1, 3])
+    orianna = Orianna(level=17, inventory=[BlastingWand()], spell_levels=[1, 1, 1, 3])
     dummy = Dummy(health=1000, bonus_resistance=30)
-    orianna.equip_item(item=BlastingWand())
     dmg = orianna.spell_r.hit_damage(dummy)
 
     assert round(dmg, 2) == 293.85

--- a/tests/champions/test_xerath.py
+++ b/tests/champions/test_xerath.py
@@ -8,7 +8,7 @@ def test_dummy_0_res():
     xerath = Xerath(level=18, spell_levels=[1,1,1,1])
     assert round(xerath.spell_q.hit_damage(dummy)) == 70
 
-    xerath.equip_item(BlastingWand())
+    xerath = Xerath(level=18, inventory=[BlastingWand()], spell_levels=[1, 1, 1, 1])
     damage_per_level = [104, 144, 184, 224, 264]
     for spell_level in range(1, 6):
         xerath.spell_q.set_level(spell_level)

--- a/tests/test_champion.py
+++ b/tests/test_champion.py
@@ -2,7 +2,7 @@ import math
 
 from tootanky.champion import Dummy
 from tootanky.champions import Ahri, Annie, Darius
-from tootanky.item import ALL_ITEM_CLASSES, BlastingWand
+from tootanky.item import ALL_ITEM_CLASSES, BlastingWand, RubyCrystal
 
 
 def test_auto_attack_lvl1():
@@ -84,9 +84,8 @@ def test_get_stats():
 
 
 def test_annie_q():
-    annie = Annie(level=17, spell_levels=[5, 5, 5, 5])
+    annie = Annie(level=17, inventory=[BlastingWand()], spell_levels=[5, 5, 5, 5])
     dummy = Dummy(health=1000, bonus_resistance=30)
-    annie.equip_item(item=BlastingWand())
     dmg = annie.spell_q.hit_damage(dummy)
 
     assert round(dmg, 2) == 193.85
@@ -129,5 +128,5 @@ def test_darius_auto_attack():
 def test_equip_item_health():
     ahri = Ahri(level=17, spell_levels=[5, 5, 5, 5])
     assert math.ceil(ahri.health) == 2080
-    ahri.equip_item(ALL_ITEM_CLASSES["Ruby Crystal"]())
+    ahri = Ahri(level=17, inventory=[RubyCrystal()], spell_levels=[5, 5, 5, 5])
     assert math.ceil(ahri.health) == 2230

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -10,33 +10,14 @@ def test_inventory():
     assert inventory.item_stats.crit_chance == 0.35
     assert inventory.item_stats.attack_speed == 0.2
     assert inventory.item_stats.armor_pen_percent == 0
-    inventory.add_item(SeryldaGrudge())
+    inventory = Inventory([LongSword(), Galeforce(), LongSword(), CloakofAgility(), SeryldaGrudge()])
     assert inventory.item_type_count["Legendary"] == 1
     assert inventory.item_type_count["Mythic"] == 1
     assert inventory.item_stats.attack_damage == 125
     assert inventory.item_stats.crit_chance == 0.35
     assert inventory.item_stats.attack_speed == 0.2
     assert inventory.item_stats.armor_pen_percent == 0.3
-    inventory.remove_item("Serylda's Grudge")
-    assert inventory.item_type_count["Legendary"] == 0
-    assert inventory.item_type_count["Mythic"] == 1
-    assert inventory.item_stats.attack_damage == 80
-    assert inventory.item_stats.crit_chance == 0.35
-    assert inventory.item_stats.attack_speed == 0.2
-    assert round(inventory.item_stats.armor_pen_percent) == 0
     # Test of unique passive feature
-    inventory.remove_item("Long Sword")
-    inventory.add_item(SerratedDirk())
-    assert inventory.item_type_count["Legendary"] == 0
-    assert inventory.item_type_count["Mythic"] == 1
-    assert inventory.item_stats.attack_damage == 100
+    inventory = Inventory([LongSword(), Galeforce(), SerratedDirk(), CloakofAgility(), SeryldaGrudge(), SerratedDirk()])
+    assert inventory.item_stats.attack_damage == 175
     assert inventory.item_stats.lethality == 10
-    inventory.add_item(SerratedDirk())
-    assert inventory.item_stats.attack_damage == 130
-    assert inventory.item_stats.lethality == 10
-    inventory.remove_item("Serrated Dirk")
-    assert inventory.item_stats.attack_damage == 100
-    assert inventory.item_stats.lethality == 10
-    inventory.remove_item("Serrated Dirk")
-    assert inventory.item_stats.attack_damage == 70
-    assert inventory.item_stats.lethality == 0

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -27,7 +27,9 @@ def test_serrated_unique_passive():
     assert ahri.orig_bonus_stats.lethality == 10
     assert ahri.orig_bonus_stats.armor_pen_percent == 0.18
 
-    ahri.equip_item(ALL_ITEM_CLASSES["Serrated Dirk"]())
+    item_names = ["Serrated Dirk", "Last Whisper", "Serrated Dirk"]
+    inventory = [ALL_ITEM_CLASSES[item_name]() for item_name in item_names]
+    ahri = Ahri(level=7, inventory=inventory)
 
     assert ahri.orig_bonus_stats.attack_damage == 80
     assert ahri.orig_bonus_stats.lethality == 10

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -13,7 +13,6 @@ class BaseChampion:
     """
     Base class to represent a champion. It is initialized with the stats of a champion at a given level.
     Some mechanisms are shared accross all champions:
-        - equip_item
         - auto attack
     """
 
@@ -96,18 +95,6 @@ class BaseChampion:
         selected_item = self.inventory.get_item(item_name)
         assert hasattr(selected_item, "apply_active"), "The item {} does not have an active.".format(item_name)
         return selected_item.apply_active(target)
-
-    def equip_item(self, item: BaseItem):
-        item.champion = self
-        self.inventory.add_item(item)
-        self.orig_bonus_stats = self.get_bonus_stats()
-        self.update_champion_stats()
-
-    def unequip_item(self, item_name: str):
-        # TODO: This has not been tested yet. Only inventory.remove_item has been tested
-        self.inventory.remove_item(item_name)
-        self.orig_bonus_stats = self.get_bonus_stats()
-        self.update_champion_stats()
 
     def auto_attack_damage(self, target, is_crit: bool = False):
         """Calculates the damage dealt to an enemy champion with an autoattack"""

--- a/tootanky/inventory.py
+++ b/tootanky/inventory.py
@@ -15,7 +15,11 @@ class Inventory:
             assert len(items) <= 6, "Inventory can't contain more than 6 items."
             for item in items:
                 item.champion = champion
-                self.add_item(item)
+                self.item_type_count[item.type] += 1
+                self.items.append(item)
+                self.check_item(item)
+                self.apply_item_passive(item)
+                self.item_stats = self.item_stats + item.stats
 
     def get_item(self, name):
         # TODO: what happens with this method when there are several copies of the same item in the inventory
@@ -67,26 +71,6 @@ class Inventory:
         for item in self.items:
             price += item.gold
         return price
-
-    def add_item(self, item):
-        assert len(self.items) <= 5, "Inventory can't contain more than 6 items."
-        self.item_type_count[item.type] += 1
-        self.items.append(item)
-        self.check_item(item)
-        self.apply_item_passive(item)
-        self.item_stats = self.item_stats + item.stats
-
-    def remove_item(self, name):
-        indexes = self.get_all_indexes(name)
-        assert len(indexes) != 0, "The item {} is not in the inventory.".format(name)
-        # by default, we remove the last occurence to remove an item that did not apply its unique passive
-        item = self.items.pop(indexes[-1])
-        self.item_type_count[item.type] -= 1
-        if hasattr(item, "passive"):
-            if item.passive.unique:
-                if len(indexes) == 1:
-                    self.unique_item_passives.remove(item.passive.name)
-        self.item_stats = self.item_stats - item.stats
 
     def mythic_passive_stats(self):
         # TODO


### PR DESCRIPTION
Equip item and unequip item is useless. You never change ur inventory in the middle of a fight. 
Now champions must be reinitialized with another inventory when you want to test another set of items