### PR TITLE
Jarvan/Black Cleaver

### DIFF
--- a/tests/champions/test_jarvan.py
+++ b/tests/champions/test_jarvan.py
@@ -7,8 +7,10 @@ def test_q():
     champion_levels = [1, 4, 5, 7, 9]
     damage_values = [61, 85, 108, 132, 155]
     armor_values = [63, 60, 57, 55, 52]
+    dummy = Dummy(bonus_resistance=70)
     for spell_level in range(5):
         jarvan = JarvanIV(level=champion_levels[spell_level], inventory=[LongSword()])
-        dummy = Dummy(bonus_resistance=70)
         assert round(jarvan.spell_q.hit_damage(dummy)) == damage_values[spell_level]
         assert round(dummy.armor) == armor_values[spell_level]
+        jarvan.spell_q.deapply_buffs(dummy)
+        assert round(dummy.armor) == 70

--- a/tests/champions/test_jarvan.py
+++ b/tests/champions/test_jarvan.py
@@ -9,7 +9,6 @@ def test_q():
     armor_values = [63, 60, 57, 55, 52]
     dummy = Dummy(bonus_resistance=70)
     for spell_level in range(5):
-        print(spell_level)
         jarvan = JarvanIV(level=champion_levels[spell_level], inventory=[LongSword()])
         assert round(jarvan.spell_q.hit_damage(dummy)) == damage_values[spell_level]
         assert round(dummy.armor) == armor_values[spell_level]

--- a/tests/champions/test_jarvan.py
+++ b/tests/champions/test_jarvan.py
@@ -1,0 +1,14 @@
+from tootanky.champion import Dummy
+from tootanky.champions import JarvanIV
+from tootanky.item import LongSword
+
+
+def test_q():
+    champion_levels = [1, 4, 5, 7, 9]
+    damage_values = [61, 85, 108, 132, 155]
+    armor_values = [63, 60, 57, 55, 52]
+    for spell_level in range(5):
+        jarvan = JarvanIV(level=champion_levels[spell_level], inventory=[LongSword()])
+        dummy = Dummy(bonus_resistance=70)
+        assert round(jarvan.spell_q.hit_damage(dummy)) == damage_values[spell_level]
+        assert round(dummy.armor) == armor_values[spell_level]

--- a/tests/champions/test_jarvan.py
+++ b/tests/champions/test_jarvan.py
@@ -9,6 +9,7 @@ def test_q():
     armor_values = [63, 60, 57, 55, 52]
     dummy = Dummy(bonus_resistance=70)
     for spell_level in range(5):
+        print(spell_level)
         jarvan = JarvanIV(level=champion_levels[spell_level], inventory=[LongSword()])
         assert round(jarvan.spell_q.hit_damage(dummy)) == damage_values[spell_level]
         assert round(dummy.armor) == armor_values[spell_level]

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -170,20 +170,12 @@ def test_mythic_passives():
 def test_black_cleaver():
     ahri = Ahri(level=7, inventory=[BlackCleaver()])
     dummy = Dummy(bonus_resistance=100)
-    ahri.do_auto_attack(dummy)
-    assert round(dummy.armor) == 95
-    ahri.do_auto_attack(dummy)
-    assert round(dummy.armor) == 90
-    ahri.do_auto_attack(dummy)
-    assert round(dummy.armor) == 85
-    ahri.do_auto_attack(dummy)
-    assert round(dummy.armor) == 80
-    ahri.do_auto_attack(dummy)
-    assert round(dummy.armor) == 75
-    ahri.do_auto_attack(dummy)
-    assert round(dummy.armor) == 70
-    ahri.do_auto_attack(dummy)
-    assert round(dummy.armor) == 70
+    damage_values = [56, 58, 59, 61, 63, 64, 66]
+    armor_values = [95, 90, 85, 80, 75, 70, 70]
+    for i in range(7):
+        assert round(ahri.auto_attack_damage(dummy)) == damage_values[i]
+        ahri.do_auto_attack(dummy)
+        assert round(dummy.armor) == armor_values[i]
     ahri.inventory.get_item("Black Cleaver").deapply_buffs(dummy)
     assert round(dummy.armor) == 100
     assert ahri.inventory.get_item("Black Cleaver").carve_stack_count == 0

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -169,22 +169,21 @@ def test_mythic_passives():
 
 def test_black_cleaver():
     ahri = Ahri(level=7, inventory=[BlackCleaver()])
-    blackcleaver = BlackCleaver()
     dummy = Dummy(bonus_resistance=100)
-    blackcleaver.apply_buffs(dummy)
+    ahri.do_auto_attack(dummy)
     assert round(dummy.armor) == 95
-    blackcleaver.apply_buffs(dummy)
+    ahri.do_auto_attack(dummy)
     assert round(dummy.armor) == 90
-    blackcleaver.apply_buffs(dummy)
+    ahri.do_auto_attack(dummy)
     assert round(dummy.armor) == 85
-    blackcleaver.apply_buffs(dummy)
+    ahri.do_auto_attack(dummy)
     assert round(dummy.armor) == 80
-    blackcleaver.apply_buffs(dummy)
+    ahri.do_auto_attack(dummy)
     assert round(dummy.armor) == 75
-    blackcleaver.apply_buffs(dummy)
+    ahri.do_auto_attack(dummy)
     assert round(dummy.armor) == 70
-    blackcleaver.apply_buffs(dummy)
+    ahri.do_auto_attack(dummy)
     assert round(dummy.armor) == 70
-    blackcleaver.deapply_buffs(dummy)
+    ahri.inventory.get_item("Black Cleaver").deapply_buffs(dummy)
     assert round(dummy.armor) == 100
-    assert blackcleaver.carve_stack_count == 0
+    assert ahri.inventory.get_item("Black Cleaver").carve_stack_count == 0

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -170,9 +170,9 @@ def test_mythic_passives():
 def test_black_cleaver():
     ahri = Ahri(level=7, inventory=[BlackCleaver()])
     dummy = Dummy(bonus_resistance=100)
-    damage_values = [56, 58, 59, 61, 63, 64, 66]
-    armor_values = [95, 90, 85, 80, 75, 70, 70]
-    for i in range(7):
+    damage_values = [56, 58, 59, 61, 63, 64, 66, 66]
+    armor_values = [95, 90, 85, 80, 75, 70, 70, 70]
+    for i in range(8):
         assert round(ahri.auto_attack_damage(dummy)) == damage_values[i]
         ahri.do_auto_attack(dummy)
         assert round(dummy.armor) == armor_values[i]

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -12,6 +12,7 @@ from tootanky.item import (
     CloakofAgility,
     RabadonsDeathcap,
     BlastingWand,
+    BlackCleaver,
 )
 
 
@@ -164,3 +165,26 @@ def test_mythic_passives():
             else:
                 assert round(getattr(ahri, stat)) == value
         item_names.remove(mythic_item_name)
+
+
+def test_black_cleaver():
+    ahri = Ahri(level=7, inventory=[BlackCleaver()])
+    blackcleaver = BlackCleaver()
+    dummy = Dummy(bonus_resistance=100)
+    blackcleaver.apply_buffs(dummy)
+    assert round(dummy.armor) == 95
+    blackcleaver.apply_buffs(dummy)
+    assert round(dummy.armor) == 90
+    blackcleaver.apply_buffs(dummy)
+    assert round(dummy.armor) == 85
+    blackcleaver.apply_buffs(dummy)
+    assert round(dummy.armor) == 80
+    blackcleaver.apply_buffs(dummy)
+    assert round(dummy.armor) == 75
+    blackcleaver.apply_buffs(dummy)
+    assert round(dummy.armor) == 70
+    blackcleaver.apply_buffs(dummy)
+    assert round(dummy.armor) == 70
+    blackcleaver.deapply_buffs(dummy)
+    assert round(dummy.armor) == 100
+    assert blackcleaver.carve_stack_count == 0

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -156,7 +156,7 @@ class BaseChampion:
 
     def __update_champion_stats(self):
         """
-        Restores the stat depending on the stat type.
+        Updates/restores the stat depending on the stat type.
             - STAT_SUM_BASE_BONUS: set the stat as the sum of orig_base and orig_bonus stat.
             - STAT_STANDALONE: set the stat as orig_bonus stat.
             - STAT_TOTAL_PROPERTY: set base_stat, bonus_stat. the attribute stat is a property.

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -188,10 +188,10 @@ class BaseChampion:
         armor_reduction_flat = self.orig_bonus_stats.armor_reduction_flat
         armor_reduction_percent = self.orig_bonus_stats.armor_reduction_percent
         if orig_total_armor == 0:
-            self.bonus_armor -= armor_reduction_flat
+            self.bonus_armor = orig_bonus_armor - armor_reduction_flat
         else:
-            self.base_armor -= armor_reduction_flat * orig_base_armor / orig_total_armor
-            self.bonus_armor -= armor_reduction_flat * orig_bonus_armor / orig_total_armor
+            self.base_armor = orig_base_armor - armor_reduction_flat * orig_base_armor / orig_total_armor
+            self.bonus_armor = orig_bonus_armor - armor_reduction_flat * orig_bonus_armor / orig_total_armor
         if self.base_armor + self.bonus_armor > 0:
             self.base_armor *= (1 - armor_reduction_percent)
             self.bonus_armor *= (1 - armor_reduction_percent)

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -152,7 +152,6 @@ class BaseChampion:
         if self.inventory.contains("Black Cleaver"):
             carve_stack_value = self.inventory.get_item("Black Cleaver").get_carve_stack_stats(target)
             target.update_armor_stats(percent_debuff=carve_stack_value)
-        pass
 
     def __update_champion_stats(self):
         """

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -240,7 +240,6 @@ class BaseChampion:
     attack_speed = property(fget=getter_wrapper("attack_speed"))
     move_speed = property(fget=getter_wrapper("move_speed"))
 
-
     def get_bonus_stats(self):  # TODO: add runes
         """
         Get bonus stats from all sources of bonus stats (items, runes).

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -148,6 +148,12 @@ class BaseChampion:
         self.orig_base_stats.ability_power *= ap_multiplier
         self.orig_bonus_stats.ability_power *= ap_multiplier
 
+    def apply_blackcleaver(self, target):
+        if self.inventory.contains("Black Cleaver"):
+            target.orig_bonus_stats += self.inventory.get_item("Black Cleaver").get_carve_stack_stats(target)
+            target.update_champion_stats()
+        pass
+
     def restore_champion_stats(self):
         """
         Restores the stat depending on the stat type.
@@ -284,6 +290,7 @@ class BaseChampion:
 
         damage = self.auto_attack_damage(target, is_crit)
         target.take_damage(damage)
+        self.apply_blackcleaver(target)
 
     def reset_health(self):
         self.health = self.orig_base_stats.health + self.orig_bonus_stats.health

--- a/tootanky/champions/__init__.py
+++ b/tootanky/champions/__init__.py
@@ -21,6 +21,7 @@ from .caitlyn import Caitlyn
 from .darius import Darius
 from .ezreal import Ezreal
 from .irelia import Irelia
+from .jarvan import JarvanIV
 from .jax import Jax
 from .malphite import Malphite
 from .missfortune import MissFortune

--- a/tootanky/champions/jarvan.py
+++ b/tootanky/champions/jarvan.py
@@ -1,0 +1,64 @@
+from tootanky.champion import BaseChampion
+from tootanky.spell import BaseSpell
+from tootanky.spell_factory import SpellFactory
+from tootanky.damage import get_resistance_type
+
+
+class JarvanIV(BaseChampion):
+    champion_name = "JarvanIV"
+
+    def __init__(self, **kwargs):
+        super().__init__(champion_name=__class__.champion_name, spell_max_order=["q", "e", "w"], **kwargs)
+
+
+@SpellFactory.register_spell
+class QJarvanIV(BaseSpell):
+    champion_name = "JarvanIV"
+    spell_key = "q"
+
+    def __init__(self, champion, level):
+        super().__init__(champion, level=level)
+
+        self.nature = self.get_spell_nature(self.spell_key)
+        self.damage_type = "physical"
+        self.target_res_type = get_resistance_type(self.damage_type)
+        self.base_damage_per_level = [90, 130, 170, 210, 250]
+        self.ratios = [("bonus_attack_damage", 1.4)]
+        self.buffs.append(("target_armor_reduction_percent", [0.1, 0.14, 0.18, 0.22, 0.26]))
+
+        self.buff_duration = "3s"  # to have easy access to this information while coding
+
+
+@SpellFactory.register_spell
+class WJarvanIV(BaseSpell):
+    champion_name = "JarvanIV"
+    spell_key = "w"
+
+    def __init__(self, champion, level):
+        super().__init__(champion, level=level)
+
+        self.nature = self.get_spell_nature(self.spell_key)
+        self.base_spell_damage = 0
+        self.shield_per_level = [60, 80, 100, 120, 140]
+
+
+@SpellFactory.register_spell
+class EJarvanIV(BaseSpell):
+    champion_name = "JarvanIV"
+    spell_key = "e"
+
+    def __init__(self, champion, level):
+        super().__init__(champion, level=level)
+
+        self.nature = self.get_spell_nature(self.spell_key)
+
+
+@SpellFactory.register_spell
+class RJarvanIV(BaseSpell):
+    champion_name = "JarvanIV"
+    spell_key = "e"
+
+    def __init__(self, champion, level):
+        super().__init__(champion, level=level)
+
+        self.nature = self.get_spell_nature(self.spell_key)

--- a/tootanky/champions/missfortune.py
+++ b/tootanky/champions/missfortune.py
@@ -4,7 +4,7 @@ from tootanky.spell_factory import SpellFactory
 
 
 class MissFortune(BaseChampion):
-    champion_name = "Miss Fortune"
+    champion_name = "MissFortune"
 
     def __init__(self, **kwargs):
         super().__init__(champion_name=__class__.champion_name, **kwargs)
@@ -12,23 +12,23 @@ class MissFortune(BaseChampion):
 
 @SpellFactory.register_spell
 class QMissFortune(BaseSpell):
-    champion_name = "Miss Fortune"
+    champion_name = "MissFortune"
     spell_key = "q"
 
 
 @SpellFactory.register_spell
 class WMissFortune(BaseSpell):
-    champion_name = "Miss Fortune"
+    champion_name = "MissFortune"
     spell_key = "w"
 
 
 @SpellFactory.register_spell
 class EMissFortune(BaseSpell):
-    champion_name = "Miss Fortune"
+    champion_name = "MissFortune"
     spell_key = "e"
 
 
 @SpellFactory.register_spell
 class RMissFortune(BaseSpell):
-    champion_name = "Miss Fortune"
+    champion_name = "MissFortune"
     spell_key = "r"

--- a/tootanky/champions/xerath.py
+++ b/tootanky/champions/xerath.py
@@ -24,9 +24,6 @@ class QXerath(BaseSpell):
         self.base_damage_per_level = [70, 110, 150, 190, 230]
         self.ratios = [("ability_power", 0.85)]
 
-    def init_per_level(self, level):
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
-
 
 @SpellFactory.register_spell
 class WXerath(BaseSpell):
@@ -40,10 +37,9 @@ class WXerath(BaseSpell):
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [60, 95, 130, 165, 200]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
         self.ratios = [("ability_power", 0.6)]
 
-    def get_damage_modifier_coeff(self, is_empowered = True):
+    def get_damage_modifier_coeff(self, is_empowered=True):
         return 1.667 if is_empowered else 1
 
 
@@ -59,7 +55,6 @@ class EXerath(BaseSpell):
         self.damage_type = "magical"
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [80, 110, 140, 170, 200]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
         self.ratios = [("ability_power", 0.45)]
 
 
@@ -76,7 +71,6 @@ class RXerath(BaseSpell):
         self.target_res_type = self.get_resistance_type()
         self.base_damage_per_level = [200, 250, 300]
         self.recast_per_level = [3, 4, 5]
-        self.base_spell_damage = self.base_damage_per_level[level - 1]
         self.ratios = [("ability_power", 0.45)]
 
     def get_damage_modifer_ratio(self, target: BaseChampion, nb_hit=None):

--- a/tootanky/damage.py
+++ b/tootanky/damage.py
@@ -24,18 +24,18 @@ def pre_mitigation_auto_attack_damage(
     return (tot_off_stats * crit_multiplier + damage_modifier_flat) * damage_modifier_coeff
 
 
-def ratio_damage(champion, target, ratios, spell_leve1=1) -> float:
+def ratio_stat(champion, target, ratios, spell_level=1) -> float:
     """Get the damage dealt by the ratio part of a spell, taking into account multiple ratios"""
-    damage = 0
+    stat = 0
     for stat_name, ratio in ratios:
         if "target_" in stat_name:
             stat_value = getattr(target, stat_name.replace("target_", ""))
         else:
             stat_value = getattr(champion, stat_name)
         if isinstance(ratio, list):
-            ratio = ratio[spell_leve1 - 1]
-        damage += stat_value * ratio
-    return damage
+            ratio = ratio[spell_level - 1]
+        stat += stat_value * ratio
+    return stat
 
 
 def pre_mitigation_spell_damage(

--- a/tootanky/data_parser.py
+++ b/tootanky/data_parser.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from tootanky.glossary import MAPPING_CHAMPION_STANDARD, MAPPING_ITEM_STANDARD
+from tootanky.glossary import MAPPING_CHAMPION_STANDARD, MAPPING_ITEM_STANDARD, normalize_champion_name
 
 
 # gets a list of json files from a directory
@@ -90,16 +90,30 @@ def get_champion_spell_stats(folder: str):
     return out_dict
 
 
-dataset = get_dataset_from_json("data/ddragon/champion.json")
-ALL_CHAMPION_BASE_STATS = fill_champion_stats(dataset)
+ALL_CHAMPION_BASE_STATS_ORIGINAL = fill_champion_stats(get_dataset_from_json("data/ddragon/champion.json"))
+ALL_CHAMPION_SPELLS_ORIGINAL = get_champion_spell_stats("data/raw-community-dragon/champions")
+
+ALL_CHAMPION_BASE_STATS = dict()
+ALL_CHAMPION_SPELLS = dict()
+
+for i in range(len(ALL_CHAMPION_BASE_STATS_ORIGINAL.keys())):
+    key = list(ALL_CHAMPION_BASE_STATS_ORIGINAL.keys())[i]
+    new_key = normalize_champion_name(key)
+    ALL_CHAMPION_BASE_STATS[new_key] = ALL_CHAMPION_BASE_STATS_ORIGINAL[key]
+
+for i in range(len(ALL_CHAMPION_SPELLS_ORIGINAL.keys())):
+    key = list(ALL_CHAMPION_SPELLS_ORIGINAL.keys())[i]
+    new_key = normalize_champion_name(key)
+    ALL_CHAMPION_SPELLS[new_key] = ALL_CHAMPION_SPELLS_ORIGINAL[key]
+
+assert sorted(list(ALL_CHAMPION_BASE_STATS.keys()), key=str.casefold) == sorted(ALL_CHAMPION_SPELLS.keys(), key=str.casefold)
+
 ALL_CHAMPION_BASE_STATS.update({'Dummy': {'health': 1000, 'health_perlevel': 0, 'mana': 0, 'mana_perlevel': 0,
                                           'move_speed': 0, 'armor': 0, 'armor_perlevel': 0, 'magic_resist': 0,
                                           'magic_resist_perlevel': 0, 'attack_range': 0, 'health_regen': 0,
                                           'health_regen_perlevel': 0, 'mana_regen': 0, 'mana_regen_perlevel': 0,
                                           'crit_chance': 0, 'crit_chance_perlevel': 0, 'attack_damage': 0,
                                           'attack_damage_perlevel': 0, 'attack_speed_perlevel': 0, 'attack_speed': 0}})
-
-ALL_CHAMPION_SPELLS = get_champion_spell_stats("data/raw-community-dragon/champions")
 
 item_set = get_dataset_from_json("data/ddragon/item.json")
 ALL_ITEM_STATS = fill_item_stats(item_set)

--- a/tootanky/glossary.py
+++ b/tootanky/glossary.py
@@ -1,3 +1,5 @@
+import re
+
 MAPPING_CHAMPION_STANDARD = {
     "hp": "health",
     "hpperlevel": "health_perlevel",
@@ -75,5 +77,18 @@ STAT_UNDERLYING_PROPERTY = []
 
 def normalize_champion_name(name):
     """Champion name are different in champion / spell / item json files"""
-    # TODO: normalize everything
-    return name.replace(" ", "")
+    exceptions_dict = {
+        "MonkeyKing": "Wukong",
+        "Belveth": "BelVeth",
+        "Chogath": "ChoGath",
+        "Kaisa": "KaiSa",
+        "Khazix": "KhaZix",
+        "Leblanc": "LeBlanc",
+        "Nunu": "NunuWillump",
+        "Renata": "RenataGlasc",
+        "Velkoz": "VelKoz"
+    }
+    if name in exceptions_dict.keys():
+        return exceptions_dict[name]
+
+    return re.sub('[^A-Za-z0-9]+', '', name)

--- a/tootanky/glossary.py
+++ b/tootanky/glossary.py
@@ -52,8 +52,6 @@ STAT_STANDALONE = [
     "armor_pen_flat",
     "armor_pen_percent",
     "bonus_armor_pen_percent",
-    "armor_reduction_flat",
-    "armor_reduction_percent",
     "magic_resist_pen_flat",
     "magic_resist_pen_percent",
     "crit_chance",
@@ -73,6 +71,11 @@ STAT_TOTAL_PROPERTY = [
 ]
 
 STAT_UNDERLYING_PROPERTY = []
+
+STAT_TEMPORARY_BUFF = [
+    "armor_reduction_flat",
+    "armor_reduction_percent"
+]
 
 
 def normalize_champion_name(name):

--- a/tootanky/glossary.py
+++ b/tootanky/glossary.py
@@ -50,6 +50,8 @@ STAT_STANDALONE = [
     "armor_pen_flat",
     "armor_pen_percent",
     "bonus_armor_pen_percent",
+    "armor_reduction_flat",
+    "armor_reduction_percent",
     "magic_resist_pen_flat",
     "magic_resist_pen_percent",
     "crit_chance",

--- a/tootanky/item.py
+++ b/tootanky/item.py
@@ -385,7 +385,7 @@ class BlackCleaver(BaseItem):
             )
             target.orig_bonus_stats += buff_stats
             target.update_champion_stats()
-            self.carve_stack_count += 1
+            self.carve_stack_count = 0
 
 
 class CosmicDrive(BaseItem):  # missing ability haste, passive

--- a/tootanky/item.py
+++ b/tootanky/item.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional
 
-from tootanky.damage import damage_after_resistance, ratio_damage, pre_mitigation_spell_damage, get_resistance_type
+from tootanky.damage import damage_after_resistance, ratio_stat, pre_mitigation_spell_damage, get_resistance_type
 from tootanky.data_parser import ALL_ITEM_STATS
 from tootanky.stats import Stats
 
@@ -46,7 +46,7 @@ class BaseItem:
     def damage(self, target, damage_modifier_flat=0, damage_modifier_coeff=1) -> float:
         """Calculates the damage dealt to a champion with a spell"""
 
-        ratio_dmg = ratio_damage(champion=self.champion, target=target, ratios=self.ratios)
+        ratio_dmg = ratio_stat(champion=self.champion, target=target, ratios=self.ratios)
 
         pre_mtg_dmg = pre_mitigation_spell_damage(
             self.base_damage,

--- a/tootanky/item.py
+++ b/tootanky/item.py
@@ -365,15 +365,16 @@ class BlackCleaver(BaseItem):
         super().__init__()
         self.carve_stack_count = 0
 
-    def apply_buffs(self, target, **kwargs):
+    def get_carve_stack_stats(self, target, **kwargs):
         if self.carve_stack_count < 6:
             armor_reduction_percent = getattr(target.orig_bonus_stats, "armor_reduction_percent")
             buff_stats = Stats(
                 {"armor_reduction_percent": 1 - (1 - armor_reduction_percent - 0.05)/(1 - armor_reduction_percent)}
             )
-            target.orig_bonus_stats += buff_stats
-            target.update_champion_stats()
             self.carve_stack_count += 1
+            return buff_stats
+        else:
+            return Stats()
 
     def deapply_buffs(self, target, **kwargs):
         if self.carve_stack_count > 0:

--- a/tootanky/item.py
+++ b/tootanky/item.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional
 
 from tootanky.damage import damage_after_resistance, ratio_stat, pre_mitigation_spell_damage, get_resistance_type
 from tootanky.data_parser import ALL_ITEM_STATS
@@ -358,6 +357,37 @@ class WatchfulWardstone(BaseItem):  # missing ability haste
 #  Shadowflame, Shard of True Ice, Silvermere Dawn, Spear of Shojin, Spirit Visage, Staff of Flowing Water,
 #  Sterak's Gage, Stormrazor, Sunfire Aegis, The Collector, Thornmail, Titanic Hydra, Turbo Chemtank, Umbral Glaive,
 #  Vigilant Wardstone, Void Staff, Warmog's Armor, Winter's Approach, Wit's End, Zeke's Convergence, Zhonya's Hourglass
+class BlackCleaver(BaseItem):
+    name = "Black Cleaver"
+    type = "Legendary"
+
+    def __init__(self):
+        super().__init__()
+        self.carve_stack_count = 0
+
+    def apply_buffs(self, target, **kwargs):
+        if self.carve_stack_count < 6:
+            armor_reduction_percent = getattr(target.orig_bonus_stats, "armor_reduction_percent")
+            buff_stats = Stats(
+                {"armor_reduction_percent": 1 - (1 - armor_reduction_percent - 0.05)/(1 - armor_reduction_percent)}
+            )
+            target.orig_bonus_stats += buff_stats
+            target.update_champion_stats()
+            self.carve_stack_count += 1
+
+    def deapply_buffs(self, target, **kwargs):
+        if self.carve_stack_count > 0:
+            armor_reduction_percent = getattr(target.orig_bonus_stats, "armor_reduction_percent")
+            buff_stats = Stats(
+                {"armor_reduction_percent": 1 - (
+                        1 - armor_reduction_percent + self.carve_stack_count * 0.05
+                ) / (1 - armor_reduction_percent)}
+            )
+            target.orig_bonus_stats += buff_stats
+            target.update_champion_stats()
+            self.carve_stack_count += 1
+
+
 class CosmicDrive(BaseItem):  # missing ability haste, passive
     name = "Cosmic Drive"
     type = "Legendary"

--- a/tootanky/item.py
+++ b/tootanky/item.py
@@ -367,25 +367,18 @@ class BlackCleaver(BaseItem):
 
     def get_carve_stack_stats(self, target, **kwargs):
         if self.carve_stack_count < 6:
-            armor_reduction_percent = getattr(target.orig_bonus_stats, "armor_reduction_percent")
-            buff_stats = Stats(
-                {"armor_reduction_percent": 1 - (1 - armor_reduction_percent - 0.05)/(1 - armor_reduction_percent)}
-            )
+            armor_reduction_percent = target.armor_reduction_percent
             self.carve_stack_count += 1
-            return buff_stats
+            return 1 - (1 - armor_reduction_percent - 0.05)/(1 - armor_reduction_percent)
         else:
-            return Stats()
+            return 0
 
     def deapply_buffs(self, target, **kwargs):
         if self.carve_stack_count > 0:
-            armor_reduction_percent = getattr(target.orig_bonus_stats, "armor_reduction_percent")
-            buff_stats = Stats(
-                {"armor_reduction_percent": 1 - (
-                        1 - armor_reduction_percent + self.carve_stack_count * 0.05
-                ) / (1 - armor_reduction_percent)}
-            )
-            target.orig_bonus_stats += buff_stats
-            target.update_champion_stats()
+            percent_debuff = 1 - (
+                    1 - target.armor_reduction_percent + self.carve_stack_count * 0.05
+            ) / (1 - target.armor_reduction_percent)
+            target.update_armor_stats(percent_debuff=percent_debuff)
             self.carve_stack_count = 0
 
 

--- a/tootanky/spell.py
+++ b/tootanky/spell.py
@@ -122,7 +122,7 @@ class BaseSpell:
         stats_dict = dict()
         target_stats_dict = dict()
         for stat, value_per_level in self.buffs:
-            value = value_per_level[self.level]
+            value = value_per_level[self.level - 1]
             if stat.startswith("target_"):
                 stat = stat.replace("target_", "")
                 target_stats_dict[stat] = value

--- a/tootanky/spell.py
+++ b/tootanky/spell.py
@@ -1,4 +1,4 @@
-from tootanky.damage import damage_after_resistance, pre_mitigation_spell_damage, ratio_damage, get_resistance_type
+from tootanky.damage import damage_after_resistance, pre_mitigation_spell_damage, ratio_stat, get_resistance_type
 from tootanky.data_parser import ALL_CHAMPION_SPELLS
 
 
@@ -64,7 +64,7 @@ class BaseSpell:
     def damage(self, target, damage_modifier_flat=0, damage_modifier_coeff=1) -> float:
         """Calculates the damage dealt to a champion with a spell"""
 
-        ratio_dmg = ratio_damage(champion=self.champion, target=target, ratios=self.ratios, spell_leve1=self.level)
+        ratio_dmg = ratio_stat(champion=self.champion, target=target, ratios=self.ratios, spell_leve1=self.level)
 
         pre_mtg_dmg = pre_mitigation_spell_damage(
             self.get_base_damage(),

--- a/tootanky/spell.py
+++ b/tootanky/spell.py
@@ -66,7 +66,7 @@ class BaseSpell:
     def damage(self, target, damage_modifier_flat=0, damage_modifier_coeff=1) -> float:
         """Calculates the damage dealt to a champion with a spell"""
 
-        ratio_dmg = ratio_stat(champion=self.champion, target=target, ratios=self.ratios, spell_leve1=self.level)
+        ratio_dmg = ratio_stat(champion=self.champion, target=target, ratios=self.ratios, spell_level=self.level)
 
         pre_mtg_dmg = pre_mitigation_spell_damage(
             self.get_base_damage(),
@@ -107,7 +107,7 @@ class BaseSpell:
         stats_dict = dict()
         target_stats_dict = dict()
         for stat, value_per_level in self.buffs:
-            value = value_per_level[self.level]
+            value = value_per_level[self.level - 1]
             if stat.startswith("target_"):
                 stat = stat.replace("target_", "")
                 target_stats_dict[stat] = value
@@ -133,8 +133,6 @@ class BaseSpell:
         target.orig_bonus_stats -= Stats(target_stats_dict)
         target.update_champion_stats()
 
-
-
     def hit_damage(self, target, spellblade=False, **kwargs):
         on_hit_damage = 0
         self.on_attack_state_change()
@@ -150,7 +148,7 @@ class BaseSpell:
             for on_hit_source in self.champion.on_hits:
                 on_hit_damage = on_hit_source.on_hit_effect(target)
 
-        self.apply_debuff(target, **kwargs)  # Applied after the on-hits based on test with sheen + blackcleaver
+        self.apply_buffs(target, **kwargs)  # Applied after the on-hits based on test with sheen + blackcleaver
 
         return damage + on_hit_damage
 

--- a/tootanky/spell.py
+++ b/tootanky/spell.py
@@ -1,6 +1,6 @@
 from tootanky.damage import damage_after_resistance, pre_mitigation_spell_damage, ratio_stat, get_resistance_type
 from tootanky.data_parser import ALL_CHAMPION_SPELLS
-from tootanky.stats import Stats
+from tootanky.stats import add_stat, sub_stat
 
 
 class BaseSpell:
@@ -119,9 +119,9 @@ class BaseSpell:
             else:
                 if stat.startswith("target_"):
                     stat = stat.replace("target_", "")
-                    target.orig_bonus_stats += Stats({stat: value})
+                    setattr(target, stat, add_stat(stat, getattr(target, stat), value))
                 else:
-                    self.champion.orig_bonus_stats += Stats({stat: value})
+                    setattr(self.champion, stat, add_stat(stat, getattr(self.champion, stat), value))
         if self.damage_type == "physical":
             self.champion.apply_black_cleaver(target)
 
@@ -141,9 +141,9 @@ class BaseSpell:
             else:
                 if stat.startswith("target_"):
                     stat = stat.replace("target_", "")
-                    target.orig_bonus_stats -= Stats({stat: value})
+                    setattr(target, stat, sub_stat(stat, getattr(target, stat), value))
                 else:
-                    self.champion.orig_bonus_stats -= Stats({stat: value})
+                    setattr(self.champion, stat, sub_stat(stat, getattr(self.champion, stat), value))
 
     def hit_damage(self, target, spellblade=False, **kwargs):
         on_hit_damage = 0

--- a/tootanky/spell.py
+++ b/tootanky/spell.py
@@ -116,9 +116,14 @@ class BaseSpell:
         """Effect on hit"""
         pass
 
+    def apply_debuff(self, target, **kwargs):
+        """Debuff, maybe buff later if it can handle buffs also"""
+        pass
+
     def hit_damage(self, target, **kwargs):
         damage_modifier_flat = self.get_damage_modifier_flat(**kwargs)
         damage_modifier_coeff = self.get_damage_modifier_coeff(**kwargs)
         damage = self.damage(target, damage_modifier_flat, damage_modifier_coeff)
         self.on_hit_effect(target, **kwargs)  # Be sure to compute the damage before the effect
+        self.apply_debuff(target, **kwargs)  # Applied after the on-hits based on test with sheen + blackcleaver
         return damage

--- a/tootanky/spell.py
+++ b/tootanky/spell.py
@@ -116,6 +116,8 @@ class BaseSpell:
         self.champion.orig_bonus_stats += Stats(stats_dict)
         self.champion.update_champion_stats()
         target.orig_bonus_stats += Stats(target_stats_dict)
+        if self.damage_type == "physical":
+            self.champion.apply_blackcleaver(target)
         target.update_champion_stats()
 
     def deapply_buffs(self, target, **kwargs):

--- a/tootanky/stats.py
+++ b/tootanky/stats.py
@@ -37,7 +37,7 @@ class Stats:
         for name, value in stats._dict.items():
             if name not in self._dict:
                 addition[name] = value
-            elif name.endswith("_pen_percent"):
+            elif name.endswith("_pen_percent") or name.endswith("_reduction_percent"):
                 addition[name] = 1 - (1 - self._dict.get(name)) * (1 - value)
             else:
                 addition[name] = self._dict.get(name) + value
@@ -56,7 +56,7 @@ class Stats:
         for name, value in stats._dict.items():
             if name not in self._dict:
                 subtraction[name] = -value
-            elif name.endswith("_pen_percent"):
+            elif name.endswith("_pen_percent") or name.endswith("_reduction_percent"):
                 subtraction[name] = 1 - (1 - self._dict.get(name)) / (1 - value)
             else:
                 subtraction[name] = self._dict.get(name) - value

--- a/tootanky/stats.py
+++ b/tootanky/stats.py
@@ -37,7 +37,7 @@ class Stats:
         for name, value in stats._dict.items():
             if name not in self._dict:
                 addition[name] = value
-            elif name.endswith("_pen_percent") or name.endswith("_reduction_percent"):
+            elif name.endswith("_pen_percent"):
                 addition[name] = 1 - (1 - self._dict.get(name)) * (1 - value)
             else:
                 addition[name] = self._dict.get(name) + value
@@ -56,7 +56,7 @@ class Stats:
         for name, value in stats._dict.items():
             if name not in self._dict:
                 subtraction[name] = -value
-            elif name.endswith("_pen_percent") or name.endswith("_reduction_percent"):
+            elif name.endswith("_pen_percent"):
                 subtraction[name] = 1 - (1 - self._dict.get(name)) / (1 - value)
             else:
                 subtraction[name] = self._dict.get(name) - value

--- a/tootanky/stats.py
+++ b/tootanky/stats.py
@@ -2,6 +2,20 @@ import copy
 from typing import Any, Optional
 
 
+def add_stat(name, old_value, new_value):
+    if name.endswith("_pen_percent"):
+        return 1 - (1 - old_value) * (1 - new_value)
+    else:
+        return old_value + new_value
+
+
+def sub_stat(name, old_value, new_value):
+    if name.endswith("_pen_percent"):
+        return 1 - (1 - old_value) / (1 - new_value)
+    else:
+        return old_value - new_value
+
+
 class Stats:
     """
     Champions, items, and rune shards can all be considered to have stats.
@@ -37,10 +51,8 @@ class Stats:
         for name, value in stats._dict.items():
             if name not in self._dict:
                 addition[name] = value
-            elif name.endswith("_pen_percent"):
-                addition[name] = 1 - (1 - self._dict.get(name)) * (1 - value)
             else:
-                addition[name] = self._dict.get(name) + value
+                addition[name] = add_stat(name, self._dict.get(name), value)
 
         return Stats(addition)
 
@@ -56,10 +68,8 @@ class Stats:
         for name, value in stats._dict.items():
             if name not in self._dict:
                 subtraction[name] = -value
-            elif name.endswith("_pen_percent"):
-                subtraction[name] = 1 - (1 - self._dict.get(name)) / (1 - value)
             else:
-                subtraction[name] = self._dict.get(name) - value
+                subtraction[name] = sub_stat(name, self._dict.get(name), value)
 
         return Stats(subtraction)
 


### PR DESCRIPTION
First working implem of **Jarvan Q** (which reduces a percentage of the target's armor):
- New methods in BaseSpell apply_buffs and deapply_buffs.
- In BaseChampion, update_champion_stats renamed restore_champion_stats. New update_champion_stats is called when updating stats after buffs are applied.
- New stats category STAT_TEMPORARY_BUFF
- ALL_CHAMPION_BASE_STATS and ALL_CHAMPION_SPELLS champion names are now normalized.

First working implem of **Black Cleaver**:
- BaseChampion has an apply_blackcleaver method which uses the stats gotten from BlackCleaver.get_carve_stack_stats
- BlackCleaver has deapply_buffs method to remove all stacks of BlackCleaver armor reduction
- The armor_reduction_percent of BlackCleaver is calculated so that it is equivalent to 5%,10%, 15%, 20%, 25%, 30% for 1, 2, 3, 4, 5, 6 stacks.
- Autoattacks and physical spells call apply_blackcleaver method. 
