### PR TITLE
Ability haste

### DIFF
--- a/tests/champions/test_caitlyn.py
+++ b/tests/champions/test_caitlyn.py
@@ -46,7 +46,7 @@ def test_q():
 def test_w_level_1():
     # W has no damage, but we call hit_damage to trigger the on-hit effect
     dummy = Dummy(1000, 30)
-    caitlyn = Caitlyn(level=1)
+    caitlyn = Caitlyn(level=1, spell_levels=[0, 1, 0, 0])
     assert round(caitlyn.auto_attack_damage(dummy, False)) == 48
     caitlyn.spell_w.hit_damage(dummy)
     assert round(caitlyn.auto_attack_damage(dummy, False)) == 107

--- a/tests/test_spell.py
+++ b/tests/test_spell.py
@@ -1,0 +1,19 @@
+from tootanky.champions import Caitlyn
+from tootanky.item import FiendishCodex, CaulfieldsWarhammer, WatchfulWardstone, YoumuusGhostblade, CosmicDrive, VigilantWardstone
+
+
+def test_ability_haste():
+    caitlyn = Caitlyn(level=9, inventory=[
+        CaulfieldsWarhammer(),
+        FiendishCodex(),
+        FiendishCodex(),
+        YoumuusGhostblade(),
+        WatchfulWardstone(),
+        CosmicDrive()
+    ])
+    assert caitlyn.ability_haste == 85
+    assert caitlyn.spell_q.level == 5
+    assert round(caitlyn.spell_q.cooldown, 2) == 3.24
+    assert round(caitlyn.spell_w.cooldown, 2) == 0.27
+    assert round(caitlyn.spell_e.cooldown, 2) == 8.65
+    assert round(caitlyn.spell_r.cooldown, 2) == 48.65

--- a/tests/test_spell.py
+++ b/tests/test_spell.py
@@ -17,3 +17,15 @@ def test_ability_haste():
     assert round(caitlyn.spell_w.cooldown, 2) == 0.27
     assert round(caitlyn.spell_e.cooldown, 2) == 8.65
     assert round(caitlyn.spell_r.cooldown, 2) == 48.65
+    caitlyn = Caitlyn(level=18, inventory=[
+        CaulfieldsWarhammer(),
+        FiendishCodex(),
+        VigilantWardstone(),
+        YoumuusGhostblade(),
+        CosmicDrive()
+    ])
+    assert round(caitlyn.ability_haste) == 90
+    assert round(caitlyn.spell_q.cooldown, 2) == 3.16
+    assert round(caitlyn.spell_w.cooldown, 2) == 0.26
+    assert round(caitlyn.spell_e.cooldown, 2) == 4.22
+    assert round(caitlyn.spell_r.cooldown, 2) == 31.65

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -131,7 +131,7 @@ class BaseChampion:
         Stat modifiers can affect both base and bonus stats (e.g rabadon)
         """
         self.apply_crit_damage_modifier()
-        self.apply_ap_multipliers()
+        self.apply_item_multipliers()
 
     def apply_caps(self):
         """
@@ -145,12 +145,13 @@ class BaseChampion:
             bonus_crit_damage += 0.35
         self.orig_bonus_stats.crit_damage += bonus_crit_damage
 
-    def apply_ap_multipliers(self):
+    def apply_item_multipliers(self):
         ap_multiplier = 1
         if self.inventory.contains("Vigilant Wardstone"):  # missing ability haste
             ap_multiplier += 0.12
             self.orig_bonus_stats.attack_damage *= 1.12
             self.orig_bonus_stats.health *= 1.12
+            self.orig_bonus_stats.ability_haste *= 1.12
         if self.inventory.contains("Rabadon's Deathcap"):
             ap_multiplier += 0.35
         self.orig_base_stats.ability_power *= ap_multiplier

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -26,12 +26,12 @@ class BaseChampion:
     """
 
     def __init__(
-            self,
-            champion_name: str,
-            level: int = 1,
-            inventory: Optional[List[BaseItem]] = None,
-            spell_levels: Optional[List[int]] = None,
-            spell_max_order: Optional[List[str]] = None,
+        self,
+        champion_name: str,
+        level: int = 1,
+        inventory: Optional[List[BaseItem]] = None,
+        spell_levels: Optional[List[int]] = None,
+        spell_max_order: Optional[List[str]] = None,
     ):
         assert isinstance(level, int) and 1 <= level <= 18, "Champion level should be in the [1,18] range"
         self.level = level

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -53,6 +53,8 @@ class BaseChampion:
         self.orig_bonus_stats += self.get_bonus_stats()
         self.orig_bonus_stats += self.get_mythic_passive_stats()
         self.apply_stat_modifiers()
+        self.apply_caps()  # TODO: test if caps have to be applied before or after modifiers (cannot be tested for
+        # ability haste because the cap is unattainable
         self.__update_champion_stats()
 
         self.on_hits = []
@@ -130,6 +132,12 @@ class BaseChampion:
         """
         self.apply_crit_damage_modifier()
         self.apply_ap_multipliers()
+
+    def apply_caps(self):
+        """
+        Some stats are capped at a certain amount (attack_speed, ability_haste, ...)
+        """
+        self.orig_bonus_stats.ability_haste = min(self.orig_bonus_stats.ability_haste, 500)
 
     def apply_crit_damage_modifier(self):
         bonus_crit_damage = 0

--- a/tootanky/champion.py
+++ b/tootanky/champion.py
@@ -26,12 +26,12 @@ class BaseChampion:
     """
 
     def __init__(
-        self,
-        champion_name: str,
-        inventory: Optional[List[BaseItem]] = None,
-        level: int = 1,
-        spell_levels: Optional[List[int]] = None,
-        spell_max_order: Optional[List[str]] = None,
+            self,
+            champion_name: str,
+            level: int = 1,
+            inventory: Optional[List[BaseItem]] = None,
+            spell_levels: Optional[List[int]] = None,
+            spell_max_order: Optional[List[str]] = None,
     ):
         assert isinstance(level, int) and 1 <= level <= 18, "Champion level should be in the [1,18] range"
         self.level = level

--- a/tootanky/champions/caitlyn.py
+++ b/tootanky/champions/caitlyn.py
@@ -8,7 +8,7 @@ class Caitlyn(BaseChampion):
     champion_name = "Caitlyn"
 
     def __init__(self, **kwargs):
-        super().__init__(champion_name=__class__.champion_name, **kwargs)
+        super().__init__(champion_name=__class__.champion_name, spell_max_order=["q", "w", "e"], **kwargs)
         self.auto_attack_count = 0
         self.w_hit = False
         self.e_hit = False

--- a/tootanky/damage.py
+++ b/tootanky/damage.py
@@ -1,4 +1,7 @@
-# TODO: it seems that hp are ceiled while damage floored. (however it seems that the ad is rounded in the stat section ingame)
+# COMMENTS
+# HP are ceiled, damage are floored.
+# However damage displayed in white on dummys is rounded
+# Champions stats are rounded
 
 
 def pre_mitigation_auto_attack_damage(

--- a/tootanky/data_parser.py
+++ b/tootanky/data_parser.py
@@ -82,7 +82,7 @@ def get_champion_spell_stats(folder: str):
                 "name": spell["name"],
                 "range": spell["range"],
                 "cost": spell["costCoefficients"],
-                "cooldown": spell["cooldownCoefficients"],
+                "base_cooldown_per_level": spell["cooldownCoefficients"],
                 "ratios": [spell["coefficients"]["coefficient1"], spell["coefficients"]["coefficient2"]],
                 "max_level": spell["maxLevel"],
             }

--- a/tootanky/glossary.py
+++ b/tootanky/glossary.py
@@ -58,7 +58,8 @@ STAT_STANDALONE = [
     "crit_damage",
     "life_steal",
     "omni_vamp",
-    "spell_vamp"
+    "spell_vamp",
+    "ability_haste"
 ]
 
 STAT_TOTAL_PROPERTY = [

--- a/tootanky/item.py
+++ b/tootanky/item.py
@@ -185,9 +185,13 @@ class Sheen(BaseItem):
 # TODO: Executioner's Calling, Forbidden Idol, Hexdrinker, Hextech Alternator, Ironspike Whip, Kircheis Shard,
 #  Leeching Leer, Oblivion Orb, Phage, Quicksilver Sash, Rageknife, Recurve Bow, Seeker's Armguard, Spectre's Cowl,
 #  Tiamat, Vampiric Scepter, Verdant Barrier, Warden's Mail, Winged Moonplate, Zeal
-class AegisoftheLegion(BaseItem):  # missing ability haste
+class AegisoftheLegion(BaseItem):
     name = "Aegis of the Legion"
     type = "Epic"
+
+    def __init__(self):
+        super().__init__()
+        self.stats.ability_haste = 10
 
 
 class AetherWisp(BaseItem):  # missing unique passive (bonus_move_speed)
@@ -195,9 +199,13 @@ class AetherWisp(BaseItem):  # missing unique passive (bonus_move_speed)
     type = "Epic"
 
 
-class BandleglassMirror(BaseItem):  # missing ability haste and base_mana_regen
+class BandleglassMirror(BaseItem):  # missing base_mana_regen
     name = "Bandleglass Mirror"
     type = "Epic"
+
+    def __init__(self):
+        super().__init__()
+        self.stats.ability_haste = 10
 
 
 class BlightingJewel(BaseItem):
@@ -215,9 +223,13 @@ class BrambleVest(BaseItem):  # missing passive
     type = "Epic"
 
 
-class CaulfieldsWarhammer(BaseItem):  # missing ability haste
+class CaulfieldsWarhammer(BaseItem):
     name = "Caulfield's Warhammer"
     type = "Epic"
+
+    def __init__(self):
+        super().__init__()
+        self.stats.ability_haste = 10
 
 
 class ChainVest(BaseItem):
@@ -230,9 +242,13 @@ class CrystallineBracer(BaseItem):  # missing base_health_regen
     type = "Epic"
 
 
-class FiendishCodex(BaseItem):  # missing ability haste
+class FiendishCodex(BaseItem):
     name = "Fiendish Codex"
     type = "Epic"
+
+    def __init__(self):
+        super().__init__()
+        self.stats.ability_haste = 10
 
 
 class Frostfang(BaseItem):  # missing base_mana_regen
@@ -253,6 +269,10 @@ class GlacialBuckler(BaseItem):  # missing ability haste
     name = "Glacial Buckler"
     type = "Epic"
 
+    def __init__(self):
+        super().__init__()
+        self.stats.ability_haste = 10
+
 
 class HarrowingCrescent(BaseItem):  # missing base_mana_regen
     name = "Harrowing Crescent"
@@ -268,9 +288,13 @@ class HearthboundAxe(BaseItem):  # missing passive (bonus_move_speed when basic 
     type = "Epic"
 
 
-class Kindlegem(BaseItem):  # missing ability haste
+class Kindlegem(BaseItem):
     name = "Kindlegem"
     type = "Epic"
+
+    def __init__(self):
+        super().__init__()
+        self.stats.ability_haste = 10
 
 
 class LastWhisper(BaseItem):
@@ -283,13 +307,14 @@ class LastWhisper(BaseItem):
         self.stats.armor_pen_percent = 0.18
 
 
-class LostChapter(BaseItem):  # missing ability haste
+class LostChapter(BaseItem):
     name = "Lost Chapter"
     type = "Epic"
 
     def __init__(self):
         super().__init__()
         self.limitations = ["Mythic Component"]
+        self.stats.ability_haste = 10
 
 
 class NegatronCloak(BaseItem):
@@ -336,13 +361,14 @@ class TargonsBuckler(BaseItem):  # missing base_health_regen
         self.limitations = ["Support"]
 
 
-class WatchfulWardstone(BaseItem):  # missing ability haste
+class WatchfulWardstone(BaseItem):
     name = "Watchful Wardstone"
     type = "Epic"
 
     def __init__(self):
         super().__init__()
         self.limitations = ["Sightstone"]
+        self.stats.ability_haste = 10
 
 
 # Legendary items
@@ -363,6 +389,7 @@ class BlackCleaver(BaseItem):
 
     def __init__(self):
         super().__init__()
+        self.stats.ability_haste = 30
         self.carve_stack_count = 0
 
     def get_carve_stack_stats(self, target, **kwargs):
@@ -382,9 +409,13 @@ class BlackCleaver(BaseItem):
             self.carve_stack_count = 0
 
 
-class CosmicDrive(BaseItem):  # missing ability haste, passive
+class CosmicDrive(BaseItem):  # missing passive
     name = "Cosmic Drive"
     type = "Legendary"
+
+    def __init__(self):
+        super().__init__()
+        self.stats.ability_haste = 30
 
 
 class EdgeofNight(BaseItem):  # missing passive
@@ -415,13 +446,14 @@ class NashorsTooth(BaseItem):  # missing passive
     type = "Legendary"
 
 
-class NavoriQuickblades(BaseItem):  # missing passive, ability haste
+class NavoriQuickblades(BaseItem):  # missing passive
     name = "Navori Quickblades"
     type = "Legendary"
 
     def __init__(self):
         super().__init__()
         self.limitations = ["Marksman Capstone", "Ability Haste Capstone"]
+        self.stats.ability_haste = 20
 
 
 class RabadonsDeathcap(BaseItem):
@@ -437,6 +469,7 @@ class SeryldasGrudge(BaseItem):  # missing passive, ability haste
         super().__init__()
         self.limitations = ["Last Whisper"]
         self.stats.armor_pen_percent = 0.3
+        self.stats.ability_haste = 20
 
 
 class VigilantWardstone(BaseItem):  # missing 12% ability haste increase in multiplier
@@ -444,13 +477,14 @@ class VigilantWardstone(BaseItem):  # missing 12% ability haste increase in mult
     type = "Legendary"
 
 
-class YoumuusGhostblade(BaseItem):  # missing passive, active, ability haste
+class YoumuusGhostblade(BaseItem):  # missing passive, active
     name = "Youmuu's Ghostblade"
     type = "Legendary"
 
     def __init__(self):
         super().__init__()
         self.stats.lethality = 18
+        self.stats.ability_haste = 15
 
 
 class InfinityEdge(BaseItem):
@@ -464,13 +498,14 @@ class InfinityEdge(BaseItem):
 #  Jak'Sho, The Protean, Kraken Slayer, Liandry's Anguish, Locket of the Iron Solari, Luden's Tempest,
 #  Moonstone Renewer, Night Harvester, Prowler's Claw, Radiant Virtue, Riftmaker, Rod of Ages, Shurelya's Battlesong,
 #  Stridebreaker, Trinity Force
-class Everfrost(BaseItem):  # missing ability haste
+class Everfrost(BaseItem):  # missing active
     name = "Everfrost"
     type = "Mythic"
 
     def __init__(self):
         super().__init__()
         self.mythic_passive_stats = [("ability_power", 10, "flat")]
+        self.stats.ability_haste = 20
 
 
 class Galeforce(BaseItem):

--- a/tootanky/item.py
+++ b/tootanky/item.py
@@ -472,9 +472,13 @@ class SeryldasGrudge(BaseItem):  # missing passive, ability haste
         self.stats.ability_haste = 20
 
 
-class VigilantWardstone(BaseItem):  # missing 12% ability haste increase in multiplier
+class VigilantWardstone(BaseItem):
     name = "Vigilant Wardstone"
     type = "Legendary"
+
+    def __init__(self):
+        super().__init__()
+        self.stats.ability_haste = 15
 
 
 class YoumuusGhostblade(BaseItem):  # missing passive, active
@@ -485,11 +489,6 @@ class YoumuusGhostblade(BaseItem):  # missing passive, active
         super().__init__()
         self.stats.lethality = 18
         self.stats.ability_haste = 15
-
-
-class InfinityEdge(BaseItem):
-    name = "Infinity Edge"
-    type = "Legendary"
 
 
 # Mythic items

--- a/tootanky/spell.py
+++ b/tootanky/spell.py
@@ -49,9 +49,10 @@ class BaseSpell:
 
     @property
     def cooldown(self):
-        return ALL_CHAMPION_SPELLS[self.champion.champion_name][self.spell_key]["base_cooldown_per_level"][
+        base_cooldown = ALL_CHAMPION_SPELLS[self.champion.champion_name][self.spell_key]["base_cooldown_per_level"][
                    self.level - 1
-               ] * 100 / (100 + self.champion.ability_haste)
+               ]
+        return base_cooldown * 100 / (100 + self.champion.ability_haste)
 
     def print_specs(self):
         """pretty print the stats"""

--- a/tootanky/spell.py
+++ b/tootanky/spell.py
@@ -47,6 +47,12 @@ class BaseSpell:
             return "basic"
         return "ulti"
 
+    @property
+    def cooldown(self):
+        return ALL_CHAMPION_SPELLS[self.champion.champion_name][self.spell_key]["base_cooldown_per_level"][
+                   self.level - 1
+               ] * 100 / (100 + self.champion.ability_haste)
+
     def print_specs(self):
         """pretty print the stats"""
         return print("\n".join([f"{k}: {v}" for k, v in self.__dict__.items() if k != "spell_specs"]))


### PR DESCRIPTION
- Ability haste stat added in all items. 
- Ability haste in STAT_STANDALONE category.
- "cooldown" renamed to "base_cooldown_per_level" in ALL_CHAMPION_SPELLS
- Cooldown argument in BaseSpell.
- Tests (including Vigilant Wardstone ability haste multiplier)

P.S. ability haste capped at 500 but is not possible to reach lul